### PR TITLE
Jan2 move presets from layout helper

### DIFF
--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -99,7 +99,8 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "^-!svg-react-loader.*$": "<rootDir>/__testsDrivers__/svgImportMock.js"
+      "^-!svg-react-loader.*$": "<rootDir>/__testsDrivers__/svgImportMock.js",
+      "\\.(css|less|sass|scss)$": "<rootDir>/tests/drivers/mocks/stylesImportMock.js"
     },
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/packages/gallery/src/components/gallery/index.js
+++ b/packages/gallery/src/components/gallery/index.js
@@ -16,15 +16,22 @@ import BricksGallery from './presets/bricksGallery';
 import MixGallery from './presets/mixGallery';
 import AlternateGallery from './presets/alternateGallery';
 import LAYOUTS from '../../common/constants/layout';
-import EmptyGallery from './presets/emptyGallery'
+import EmptyGallery from './presets/emptyGallery';
+import dimensionsHelper from '../helpers/dimensionsHelper';
 
 import defaultStyles from '../../common/defaultStyles';
 
 export default props => {
 
+  const domId = props.domId || Math.floor(Math.random() * 10000);
   const { styles, options, styleParams, ...otherProps } = props;
   const _styles = { ...defaultStyles, ...options, ...styles, ...styleParams };
-  const galleryProps = { ...otherProps, styles: _styles };
+  const galleryProps = { ...otherProps, styles: _styles, domId };
+  dimensionsHelper.updateParams({
+    domId: galleryProps.domId,
+    container: galleryProps.container,
+    styles: galleryProps.styles
+  });
 
   let GalleryComponent = ProGallery;
   if (isEligibleForLeanGallery(galleryProps)) {

--- a/packages/gallery/src/components/gallery/index.js
+++ b/packages/gallery/src/components/gallery/index.js
@@ -82,7 +82,6 @@ export default props => {
         GalleryComponent = EmptyGallery;
         break;
       default:
-        GalleryComponent = CollageGallery;
     }
   }
   return <GalleryComponent {...galleryProps} />

--- a/packages/gallery/src/components/gallery/index.js
+++ b/packages/gallery/src/components/gallery/index.js
@@ -79,7 +79,7 @@ export default props => {
       case LAYOUTS.ALTERNATE:
         GalleryComponent = AlternateGallery;
         break;
-      case LAYOUTS.EmptyGallery:
+      case LAYOUTS.EMPTY:
         GalleryComponent = EmptyGallery;
         break;
     }

--- a/packages/gallery/src/components/gallery/index.js
+++ b/packages/gallery/src/components/gallery/index.js
@@ -16,61 +16,67 @@ import BricksGallery from './presets/bricksGallery';
 import MixGallery from './presets/mixGallery';
 import AlternateGallery from './presets/alternateGallery';
 import LAYOUTS from '../../common/constants/layout';
+import EmptyGallery from './presets/emptyGallery'
 
 import defaultStyles from '../../common/defaultStyles';
 
 export default props => {
 
-    const {styles, options, styleParams, ...otherProps} = props;
-    const _styles = {...defaultStyles, ...options, ...styles, ...styleParams};
-    const galleryProps = {...otherProps, styles: _styles};
-    
-    let GalleryComponent = ProGallery;
-    if (isEligibleForLeanGallery(galleryProps)) {
-        GalleryComponent = LeanGallery;
-    } else {
-        const {galleryLayout}  = _styles;
-        switch (galleryLayout) {
-          case LAYOUTS.COLLAGE:
-            GalleryComponent = CollageGallery;
-            break;
-          case LAYOUTS.MASONRY:
-            GalleryComponent = MasonryGallery;
-            break;
-          case LAYOUTS.GRID:
-            GalleryComponent = GridGallery;
-            break;
-          case LAYOUTS.THUMBNAIL:
-            GalleryComponent = ThumbnailGallery;
-            break;
-          case LAYOUTS.SLIDER:
-            GalleryComponent = SliderGallery;
-            break;
-          case LAYOUTS.SLIDESHOW:
-            GalleryComponent = SlideshowGallery;
-            break;
-          case LAYOUTS.PANORAMA:
-            GalleryComponent = PanoramaGallery;
-            break;
-          case LAYOUTS.COLUMN:
-            GalleryComponent = ColumnGallery;
-            break;
-          case LAYOUTS.MAGIC:
-              GalleryComponent = MagicGallery;
-              break;
-          case LAYOUTS.FULLSIZE:
-            GalleryComponent = FullsizeGallery;
-            break;
-          case LAYOUTS.BRICKS:
-            GalleryComponent = BricksGallery;
-            break;
-          case LAYOUTS.MIX:
-            GalleryComponent = MixGallery;
-            break;
-          case LAYOUTS.ALTERNATE:
-            GalleryComponent = AlternateGallery;
-            break;
-            }
+  const { styles, options, styleParams, ...otherProps } = props;
+  const _styles = { ...defaultStyles, ...options, ...styles, ...styleParams };
+  const galleryProps = { ...otherProps, styles: _styles };
+
+  let GalleryComponent = ProGallery;
+  if (isEligibleForLeanGallery(galleryProps)) {
+    GalleryComponent = LeanGallery;
+  } else {
+    const { galleryLayout } = _styles;
+    switch (galleryLayout) {
+      case LAYOUTS.COLLAGE:
+        GalleryComponent = CollageGallery;
+        break;
+      case LAYOUTS.MASONRY:
+        GalleryComponent = MasonryGallery;
+        break;
+      case LAYOUTS.GRID:
+        GalleryComponent = GridGallery;
+        break;
+      case LAYOUTS.THUMBNAIL:
+        GalleryComponent = ThumbnailGallery;
+        break;
+      case LAYOUTS.SLIDER:
+        GalleryComponent = SliderGallery;
+        break;
+      case LAYOUTS.SLIDESHOW:
+        GalleryComponent = SlideshowGallery;
+        break;
+      case LAYOUTS.PANORAMA:
+        GalleryComponent = PanoramaGallery;
+        break;
+      case LAYOUTS.COLUMN:
+        GalleryComponent = ColumnGallery;
+        break;
+      case LAYOUTS.MAGIC:
+        GalleryComponent = MagicGallery;
+        break;
+      case LAYOUTS.FULLSIZE:
+        GalleryComponent = FullsizeGallery;
+        break;
+      case LAYOUTS.BRICKS:
+        GalleryComponent = BricksGallery;
+        break;
+      case LAYOUTS.MIX:
+        GalleryComponent = MixGallery;
+        break;
+      case LAYOUTS.ALTERNATE:
+        GalleryComponent = AlternateGallery;
+        break;
+      case LAYOUTS.EMPTY:
+        GalleryComponent = EmptyGallery;
+        break;
+      default:
+        GalleryComponent = CollageGallery;
     }
-    return <GalleryComponent {...galleryProps} />
+  }
+  return <GalleryComponent {...galleryProps} />
 }

--- a/packages/gallery/src/components/gallery/presets/alternateGallery.js
+++ b/packages/gallery/src/components/gallery/presets/alternateGallery.js
@@ -5,21 +5,43 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.ALTERNATE,
+  //params from layoutHelper
+  sampleSize: 100,
+  isVertical: true,
+  gallerySize: 86,
+  minItemSize: 50,
+  groupSize: 3,
+  chooseBestGroup: true,
+  groupTypes: '1,2h,2v,3t,3b,3l,3r,3v,3h',
+  rotatingGroupTypes: '1,3l,1,3r',
+  cubeImages: true,
+  cubeType: 'fill',
+  smartCrop: false,
+  collageDensity: 0.48,
+  galleryMargin: 0,
+  floatingImages: 0,
+  cubeRatio: 1,
+  fixedColumns: 1,
+  groupsPerStrip: 0,
+  oneRow: false,
+  placeGroupsLtr: false,
+  at: 1538490828979,
+  rotatingCropRatios: '',
 }
 export default class alternateGallery extends React.Component {
 
-    render() {
+  render() {
 
-        
 
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/alternateGallery.js
+++ b/packages/gallery/src/components/gallery/presets/alternateGallery.js
@@ -5,7 +5,8 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.ALTERNATE,
-  //params from layoutHelper
+
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   sampleSize: 100,
   isVertical: true,
   gallerySize: 86,

--- a/packages/gallery/src/components/gallery/presets/alternateGallery.js
+++ b/packages/gallery/src/components/gallery/presets/alternateGallery.js
@@ -7,7 +7,6 @@ export const fixedStyles = {
   galleryLayout: LAYOUTS.ALTERNATE,
 
   //this params were moved from the presets in layoutHelper and were not tested and checked yet.
-  sampleSize: 100,
   isVertical: true,
   gallerySize: 86,
   minItemSize: 50,
@@ -26,7 +25,6 @@ export const fixedStyles = {
   groupsPerStrip: 0,
   oneRow: false,
   placeGroupsLtr: false,
-  at: 1538490828979,
   rotatingCropRatios: '',
 }
 export default class alternateGallery extends React.Component {
@@ -42,9 +40,9 @@ export default class alternateGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/alternateGallery.js
+++ b/packages/gallery/src/components/gallery/presets/alternateGallery.js
@@ -31,16 +31,19 @@ export const fixedStyles = {
 }
 export default class alternateGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
   render() {
-
-
 
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/bricksGallery.js
+++ b/packages/gallery/src/components/gallery/presets/bricksGallery.js
@@ -7,7 +7,6 @@ export const fixedStyles = {
   galleryLayout: LAYOUTS.BRICKS,
   
   //this params were moved from the presets in layoutHelper and were not tested and checked yet.
-  sampleSize: 100,
   isVertical: true,
   gallerySize: 400,
   minItemSize: 50,
@@ -26,7 +25,6 @@ export const fixedStyles = {
   groupsPerStrip: 0,
   oneRow: false,
   placeGroupsLtr: false,
-  at: 1538487882356,
   rotatingCropRatios: '0.707,1.414,1.414,0.707',
 }
 export default class BricksGallery extends React.Component {
@@ -42,9 +40,9 @@ export default class BricksGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/bricksGallery.js
+++ b/packages/gallery/src/components/gallery/presets/bricksGallery.js
@@ -31,14 +31,19 @@ export const fixedStyles = {
 }
 export default class BricksGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
   render() {
 
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/bricksGallery.js
+++ b/packages/gallery/src/components/gallery/presets/bricksGallery.js
@@ -5,19 +5,41 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.BRICKS,
+  //params from layoutHelper
+  sampleSize: 100,
+  isVertical: true,
+  gallerySize: 400,
+  minItemSize: 50,
+  groupSize: 3,
+  chooseBestGroup: true,
+  groupTypes: '1,2h,2v,3t,3b,3l,3r,3v,3h',
+  rotatingGroupTypes: '2h',
+  cubeImages: true,
+  cubeType: 'fill',
+  smartCrop: false,
+  collageDensity: 0.8,
+  galleryMargin: 0,
+  floatingImages: 0,
+  cubeRatio: 1,
+  fixedColumns: 1,
+  groupsPerStrip: 0,
+  oneRow: false,
+  placeGroupsLtr: false,
+  at: 1538487882356,
+  rotatingCropRatios: '0.707,1.414,1.414,0.707',
 }
 export default class BricksGallery extends React.Component {
 
-    render() {
+  render() {
 
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/bricksGallery.js
+++ b/packages/gallery/src/components/gallery/presets/bricksGallery.js
@@ -5,7 +5,8 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.BRICKS,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   sampleSize: 100,
   isVertical: true,
   gallerySize: 400,

--- a/packages/gallery/src/components/gallery/presets/collageGallery.js
+++ b/packages/gallery/src/components/gallery/presets/collageGallery.js
@@ -5,7 +5,8 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.COLLAGE,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: false,
   cubeImages: false,
   groupSize: 3,

--- a/packages/gallery/src/components/gallery/presets/collageGallery.js
+++ b/packages/gallery/src/components/gallery/presets/collageGallery.js
@@ -24,17 +24,21 @@ export const fixedStyles = {
 }
 export default class CollageGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+      gallerySize: Math.round(this.props.styles.gallerySize * 5 + 500),
+    }
+  }
+
   render() {
-
-
 
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles,
-          gallerySize: Math.round(this.props.styles.gallerySize * 5 + 500) // ask guy about this solution
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/collageGallery.js
+++ b/packages/gallery/src/components/gallery/presets/collageGallery.js
@@ -5,21 +5,37 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.COLLAGE,
+  //params from layoutHelper
+  showArrows: false,
+  cubeImages: false,
+  groupSize: 3,
+  groupTypes: '1,2h,2v,3t,3b,3l,3r',
+  gallerySize: 0,
+  fixedColumns: 0,
+  hasThumbnails: false,
+  enableScroll: true,
+  isGrid: false,
+  isSlider: false,
+  isMasonry: false,
+  isColumns: false,
+  isSlideshow: false,
+  cropOnlyFill: false,
 }
 export default class CollageGallery extends React.Component {
 
-    render() {
+  render() {
 
-        
 
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles,
+          gallerySize: Math.round(this.props.styles.gallerySize * 5 + 500) // ask guy about this solution
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/collageGallery.js
+++ b/packages/gallery/src/components/gallery/presets/collageGallery.js
@@ -37,9 +37,9 @@ export default class CollageGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/columnGallery.js
+++ b/packages/gallery/src/components/gallery/presets/columnGallery.js
@@ -2,21 +2,43 @@
 import React from 'react';
 import ProGallery from '../proGallery/proGallery';
 import LAYOUTS from '../../../common/constants/layout';
+import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.COLUMN,
+  //params from layoutHelper
+  showArrows: true,
+  cubeImages: true,
+  smartCrop: false,
+  cubeType: 'fill',
+  cubeRatio: 0.35,
+  isVertical: false,
+  galleryType: 'Strips',
+  groupSize: 1,
+  groupTypes: '1',
+  gallerySize: () => dimensionsHelper.getGalleryHeight(),
+  fixedColumns: 0,
+  hasThumbnails: false,
+  oneRow: true,
+  enableScroll: true,
+  isGrid: false,
+  isColumns: true,
+  isMasonry: false,
+  isSlider: false,
+  isSlideshow: false,
+  cropOnlyFill: false,
 }
 export default class ColumnGallery extends React.Component {
 
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/columnGallery.js
+++ b/packages/gallery/src/components/gallery/presets/columnGallery.js
@@ -30,14 +30,20 @@ export const fixedStyles = {
   cropOnlyFill: false,
 }
 export default class ColumnGallery extends React.Component {
+  
+  createStyles = () =>{
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
 
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles()
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/columnGallery.js
+++ b/packages/gallery/src/components/gallery/presets/columnGallery.js
@@ -42,9 +42,9 @@ export default class ColumnGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles()
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/columnGallery.js
+++ b/packages/gallery/src/components/gallery/presets/columnGallery.js
@@ -6,7 +6,8 @@ import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.COLUMN,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: true,
   cubeImages: true,
   smartCrop: false,

--- a/packages/gallery/src/components/gallery/presets/emptyGallery.js
+++ b/packages/gallery/src/components/gallery/presets/emptyGallery.js
@@ -7,15 +7,21 @@ export const fixedStyles = {
   galleryLayout: LAYOUTS.EMPTY,
 }
 export default class ColumnGallery extends React.Component {
+  
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+      gallerySize: Math.round(this.props.styles.gallerySize * 9 + 100)
+    }
+  }
 
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles,
-          gallerySize: Math.round(this.props.styles.gallerySize * 9 + 100)
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/emptyGallery.js
+++ b/packages/gallery/src/components/gallery/presets/emptyGallery.js
@@ -6,7 +6,7 @@ import LAYOUTS from '../../../common/constants/layout';
 export const fixedStyles = {
   galleryLayout: LAYOUTS.EMPTY,
 }
-export default class ColumnGallery extends React.Component {
+export default class EmptyGallery extends React.Component {
   
   createStyles = () => {
     return {
@@ -20,9 +20,9 @@ export default class ColumnGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/emptyGallery.js
+++ b/packages/gallery/src/components/gallery/presets/emptyGallery.js
@@ -1,0 +1,23 @@
+
+import React from 'react';
+import ProGallery from '../proGallery/proGallery';
+import LAYOUTS from '../../../common/constants/layout';
+
+export const fixedStyles = {
+  galleryLayout: LAYOUTS.EMPTY,
+}
+export default class ColumnGallery extends React.Component {
+
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles,
+          gallerySize: Math.round(this.props.styles.gallerySize * 9 + 100)
+        }}
+      />
+    );
+  }
+}

--- a/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
+++ b/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
@@ -2,21 +2,46 @@
 import React from 'react';
 import ProGallery from '../proGallery/proGallery';
 import LAYOUTS from '../../../common/constants/layout';
+import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.FULLSIZE,
+  //params from layoutHelper
+  showArrows: true,
+  cubeImages: true,
+  smartCrop: false,
+  cubeType: 'fill',
+  cubeRatio: '100%/100%',
+  isVertical: false,
+  galleryType: 'Strips',
+  groupSize: 1,
+  gallerySize: () => dimensionsHelper.getGalleryWidth(),
+  groupTypes: '1',
+  oneRow: true,
+  hasThumbnails: false,
+  enableScroll: true,
+  scrollSnap: true,
+  isGrid: false,
+  isSlider: false,
+  isColumns: false,
+  isMasonry: false,
+  isSlideshow: false,
+  cropOnlyFill: false,
+  floatingImages: 0,
+  galleryMargin: 0,
+  imageMargin: 0,
 }
 export default class FullsizeGallery extends React.Component {
 
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
+++ b/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
@@ -6,7 +6,8 @@ import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.FULLSIZE,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: true,
   cubeImages: true,
   smartCrop: false,

--- a/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
+++ b/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
@@ -45,9 +45,9 @@ export default class FullsizeGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
+++ b/packages/gallery/src/components/gallery/presets/fullsizeGallery.js
@@ -34,13 +34,19 @@ export const fixedStyles = {
 }
 export default class FullsizeGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
+
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/gridGallery.js
+++ b/packages/gallery/src/components/gallery/presets/gridGallery.js
@@ -13,7 +13,7 @@ export const fixedStyles = {
   galleryType: 'Columns',
   groupSize: 1,
   groupTypes: '1',
-  fixedColumns: undefined,
+  fixedColumns: 0,
   gallerySize: 0,
   hasThumbnails: false,
   enableScroll: true,
@@ -39,10 +39,9 @@ export default class GridGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-          
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/gridGallery.js
+++ b/packages/gallery/src/components/gallery/presets/gridGallery.js
@@ -4,7 +4,8 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.GRID,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: false,
   cubeImages: true,
   smartCrop: false,

--- a/packages/gallery/src/components/gallery/presets/gridGallery.js
+++ b/packages/gallery/src/components/gallery/presets/gridGallery.js
@@ -4,18 +4,38 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.GRID,
+  //params from layoutHelper
+  showArrows: false,
+  cubeImages: true,
+  smartCrop: false,
+  isVertical: true,
+  galleryType: 'Columns',
+  groupSize: 1,
+  groupTypes: '1',
+  fixedColumns: undefined,
+  gallerySize: 0,
+  hasThumbnails: false,
+  enableScroll: true,
+  cropOnlyFill: false,
+  isSlider: false,
+  isColumns: false,
+  isGrid: true,
+  isMasonry: false,
+  isSlideshow: false,
+  minItemSize: 50,
 }
 export default class GridGallery extends React.Component {
 
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles,
+          gallerySize: Math.round(this.props.styles.gallerySize * 8.5 + 150)
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/gridGallery.js
+++ b/packages/gallery/src/components/gallery/presets/gridGallery.js
@@ -27,14 +27,21 @@ export const fixedStyles = {
 }
 export default class GridGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+      gallerySize: Math.round(this.props.styles.gallerySize * 8.5 + 150),
+    }
+  }
+
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles,
-          gallerySize: Math.round(this.props.styles.gallerySize * 8.5 + 150)
+          ...this.createStyles(),
+          
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/magicGallery.js
+++ b/packages/gallery/src/components/gallery/presets/magicGallery.js
@@ -2,21 +2,131 @@
 import React from 'react';
 import ProGallery from '../proGallery/proGallery';
 import LAYOUTS from '../../../common/constants/layout';
+import { featureManager } from '../../helpers/versionsHelper';
+
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.MAGIC,
+  cubeImages: undefined,
+  cubeRatio: undefined,
+  isVertical: undefined,
+  gallerySize: undefined,
+  collageAmount: undefined,
+  collageDensity:undefined,
+  groupTypes: undefined,
+  oneRow: undefined,// later on in layoutHelper this can be changed if it is false, so not exactly fixed.
+  imageMargin: undefined,
+  floatingImages: undefined,
+  galleryMargin: undefined,
+  chooseBestGroup: undefined,
+  smartCrop: undefined,
+  showArrows: undefined,
+  cubeType: undefined,
+  hasThumbnails: undefined,
+  enableScroll: undefined,
+  isGrid: undefined,
+  isSlideshow: undefined,
+  isSlider: undefined,
+  isColumns: undefined,
+  cropOnlyFill: undefined,
+  fixedColumns: undefined,
+  enableInfiniteScroll: undefined,
 }
 export default class MagicGallery extends React.Component {
 
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
+  getStyleBySeed(seed) {
+    if (!seed > 0) {
+      seed = 999999;
     }
+    seed = Math.floor(seed);
+
+    const strToSeed = str => {
+      str = String(str);
+      let total = 0;
+      for (let s = 0; s < str.length; s++) {
+        total += str.charCodeAt(s);
+      }
+      return total;
+    };
+
+    const mergeSeeds = (s1, s2) => {
+      return Math.floor((s1 / s2 - Math.floor(s1 / s2)) * 10000000);
+    };
+
+    const numFromSeed = (min, max, strSeed) => {
+      const seed2 = strToSeed(strSeed);
+      const range = max - min + 1;
+      return (mergeSeeds(seed, seed2) % range) + min;
+    };
+
+    const boolFromSeed = strSeed => {
+      return !!numFromSeed(0, 1, strSeed);
+    };
+
+    const style = {
+      cubeImages: boolFromSeed('cubeImages'),
+      cubeRatio: numFromSeed(1, 25, 'cubeRatio') / 5,
+      isVertical: boolFromSeed('isVertical'),
+      gallerySize: numFromSeed(300, 800, 'gallerySize'),
+      collageAmount: numFromSeed(5, 10, 'collageAmount') / 10,
+      collageDensity:
+        (featureManager.supports.spacingCalculation
+          ? numFromSeed(1, 100, 'collageDensity')
+          : numFromSeed(5, 10, 'collageDensity')) / 100,
+      groupTypes: ['1'].concat(
+        ('2h,2v,3t,3b,3l,3r,3h,3v').split(',').filter((type, i) =>
+          boolFromSeed('groupTypes' + i),
+        ),
+      ),
+      oneRow: boolFromSeed('oneRow'),
+      imageMargin: numFromSeed(
+        0,
+        featureManager.supports.spacingCalculation
+          ? numFromSeed(300, 800, 'gallerySize') / 5
+          : 5,
+        'imageMargin',
+      ),
+      galleryMargin: featureManager.supports.spacingCalculation
+        ? 0
+        : numFromSeed(0, 5, 'imageMargin'),
+      floatingImages: 0,
+      chooseBestGroup: boolFromSeed('chooseBestGroup'),
+      smartCrop: boolFromSeed('smartCrop'),
+      showArrows: false,
+      cubeType: 'fill',
+      hasThumbnails: false,
+      enableScroll: true,
+      isGrid: false,
+      isSlideshow: false,
+      isSlider: false,
+      isColumns: false,
+      cropOnlyFill: false,
+      fixedColumns: 0,
+      enableInfiniteScroll: 1,
+    };
+
+    //force adjustments
+    if (style.oneRow) {
+      style.isVertical = false;
+    }
+    style.galleryType = style.isVertical ? 'Columns' : 'Strips';
+    style.groupSize = parseInt(style.groupTypes.slice(-1)[0]);
+    style.groupTypes = style.groupTypes.join(',');
+    style.minItemSize = style.gallerySize / style.groupSize / 2;
+
+    return style;
+  }
+
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles,
+          ...this.getStyleBySeed(this.props.styles.magicLayoutSeed)
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/magicGallery.js
+++ b/packages/gallery/src/components/gallery/presets/magicGallery.js
@@ -117,15 +117,21 @@ export default class MagicGallery extends React.Component {
     return style;
   }
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+      ...this.getStyleBySeed(this.props.styles.magicLayoutSeed)
+    }
+  }
+
   render() {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.props.styles,
-          ...fixedStyles,
-          ...this.getStyleBySeed(this.props.styles.magicLayoutSeed)
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/masonryGallery.js
+++ b/packages/gallery/src/components/gallery/presets/masonryGallery.js
@@ -5,19 +5,36 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.MASONRY,
+  //params from layoutHelper
+  showArrows: false,
+  cubeImages: false,
+  groupSize: 1,
+  groupTypes: '1',
+  gallerySize: 0,
+  fixedColumns: 0,
+  hasThumbnails: false,
+  enableScroll: true,
+  isGrid: false,
+  isSlider: false,
+  isMasonry: true,
+  isColumns: false,
+  isSlideshow: false,
+  cropOnlyFill: false,
+  oneRow: false,
 }
 export default class MasonryGallery extends React.Component {
 
-    render() {
+  render() {
 
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles,
+          gallerySize: this.props.styles.gallerySize
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/masonryGallery.js
+++ b/packages/gallery/src/components/gallery/presets/masonryGallery.js
@@ -25,15 +25,21 @@ export const fixedStyles = {
 }
 export default class MasonryGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+      gallerySize: this.props.styles.gallerySize,
+    }
+  }
+
   render() {
 
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles,
-          gallerySize: this.props.styles.gallerySize
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/masonryGallery.js
+++ b/packages/gallery/src/components/gallery/presets/masonryGallery.js
@@ -38,9 +38,9 @@ export default class MasonryGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/masonryGallery.js
+++ b/packages/gallery/src/components/gallery/presets/masonryGallery.js
@@ -5,7 +5,8 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.MASONRY,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: false,
   cubeImages: false,
   groupSize: 1,

--- a/packages/gallery/src/components/gallery/presets/mixGallery.js
+++ b/packages/gallery/src/components/gallery/presets/mixGallery.js
@@ -31,13 +31,19 @@ export const fixedStyles = {
 }
 export default class MixGallery extends React.Component {
 
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
+
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/mixGallery.js
+++ b/packages/gallery/src/components/gallery/presets/mixGallery.js
@@ -5,18 +5,40 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.MIX,
+  //params from layoutHelper
+  sampleSize: 100,
+  isVertical: true,
+  gallerySize: 86,
+  minItemSize: 50,
+  groupSize: 3,
+  chooseBestGroup: true,
+  groupTypes: '1,2h,2v,3t,3b,3l,3r,3v,3h',
+  rotatingGroupTypes: '1,2h,1,2h',
+  cubeImages: true,
+  cubeType: 'fill',
+  smartCrop: false,
+  collageDensity: 0.48,
+  galleryMargin: 0,
+  floatingImages: 0,
+  cubeRatio: 1,
+  fixedColumns: 1,
+  groupsPerStrip: 0,
+  oneRow: false,
+  placeGroupsLtr: false,
+  at: 1538490323024,
+  rotatingCropRatios: '',
 }
-export default class  MixGallery extends React.Component {
+export default class MixGallery extends React.Component {
 
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/mixGallery.js
+++ b/packages/gallery/src/components/gallery/presets/mixGallery.js
@@ -7,7 +7,6 @@ export const fixedStyles = {
   galleryLayout: LAYOUTS.MIX,
   
   //this params were moved from the presets in layoutHelper and were not tested and checked yet.
-  sampleSize: 100,
   isVertical: true,
   gallerySize: 86,
   minItemSize: 50,
@@ -26,7 +25,6 @@ export const fixedStyles = {
   groupsPerStrip: 0,
   oneRow: false,
   placeGroupsLtr: false,
-  at: 1538490323024,
   rotatingCropRatios: '',
 }
 export default class MixGallery extends React.Component {
@@ -42,9 +40,9 @@ export default class MixGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/mixGallery.js
+++ b/packages/gallery/src/components/gallery/presets/mixGallery.js
@@ -5,7 +5,8 @@ import LAYOUTS from '../../../common/constants/layout';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.MIX,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   sampleSize: 100,
   isVertical: true,
   gallerySize: 86,

--- a/packages/gallery/src/components/gallery/presets/panoramaGallery.js
+++ b/packages/gallery/src/components/gallery/presets/panoramaGallery.js
@@ -2,20 +2,40 @@
 import React from 'react';
 import ProGallery from '../proGallery/proGallery';
 import LAYOUTS from '../../../common/constants/layout';
+import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.PANORAMA,
+  //params from layoutHelper
+  showArrows: false,
+  cubeImages: false,
+  isVertical: true,
+  galleryType: 'Columns',
+  groupSize: 1,
+  groupTypes: '1',
+  gallerySize: () => dimensionsHelper.getGalleryWidth(),
+  oneRow: false,
+  fixedColumns: 1,
+  hasThumbnails: false,
+  enableScroll: true,
+  isGrid: false,
+  isColumns: false,
+  isMasonry: false,
+  isSlider: false,
+  isSlideshow: false,
+  cropOnlyFill: false,
+  slideshowLoop: false,
 }
 export default class PanoramaGallery extends React.Component {
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/panoramaGallery.js
+++ b/packages/gallery/src/components/gallery/presets/panoramaGallery.js
@@ -28,13 +28,20 @@ export const fixedStyles = {
   slideshowLoop: false,
 }
 export default class PanoramaGallery extends React.Component {
+
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
+
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/panoramaGallery.js
+++ b/packages/gallery/src/components/gallery/presets/panoramaGallery.js
@@ -6,7 +6,8 @@ import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.PANORAMA,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: false,
   cubeImages: false,
   isVertical: true,

--- a/packages/gallery/src/components/gallery/presets/panoramaGallery.js
+++ b/packages/gallery/src/components/gallery/presets/panoramaGallery.js
@@ -40,9 +40,9 @@ export default class PanoramaGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/sliderGallery.js
+++ b/packages/gallery/src/components/gallery/presets/sliderGallery.js
@@ -43,9 +43,9 @@ export default class SliderGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/sliderGallery.js
+++ b/packages/gallery/src/components/gallery/presets/sliderGallery.js
@@ -2,21 +2,45 @@
 import React from 'react';
 import ProGallery from '../proGallery/proGallery';
 import LAYOUTS from '../../../common/constants/layout';
+import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
+  //tested params
   galleryLayout: LAYOUTS.SLIDER,
-  enableInfiniteScroll: true
+  enableInfiniteScroll: true,
+  //params from layout helper
+  showArrows: true,
+  cubeImages: true,
+  smartCrop: false,
+  isVertical: false,
+  galleryType: 'Strips',
+  groupSize: 1,
+  groupTypes: '1',
+  gallerySize: () => dimensionsHelper.getGalleryHeight(),
+  oneRow: true,
+  hasThumbnails: false,
+  enableScroll: true,
+  scrollSnap: true,
+  isGrid: false,
+  isSlider: true,
+  isColumns: false,
+  isMasonry: false,
+  isSlideshow: false,
+  cropOnlyFill: true,
+
 }
 export default class SliderGallery extends React.Component {
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    // console.log(dimensionsHelper.getGalleryHeight(),this.props);
+    
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/presets/sliderGallery.js
+++ b/packages/gallery/src/components/gallery/presets/sliderGallery.js
@@ -8,7 +8,8 @@ export const fixedStyles = {
   //tested params
   galleryLayout: LAYOUTS.SLIDER,
   enableInfiniteScroll: true,
-  //params from layout helper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: true,
   cubeImages: true,
   smartCrop: false,

--- a/packages/gallery/src/components/gallery/presets/sliderGallery.js
+++ b/packages/gallery/src/components/gallery/presets/sliderGallery.js
@@ -31,7 +31,6 @@ export const fixedStyles = {
 }
 export default class SliderGallery extends React.Component {
   render() {
-    // console.log(dimensionsHelper.getGalleryHeight(),this.props);
     
     return (
       <ProGallery

--- a/packages/gallery/src/components/gallery/presets/sliderGallery.js
+++ b/packages/gallery/src/components/gallery/presets/sliderGallery.js
@@ -31,14 +31,20 @@ export const fixedStyles = {
 
 }
 export default class SliderGallery extends React.Component {
+
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
   render() {
     
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/slideshowGallery.js
+++ b/packages/gallery/src/components/gallery/presets/slideshowGallery.js
@@ -5,7 +5,31 @@ import LAYOUTS from '../../../common/constants/layout';
 export const fixedStyles = {
   galleryLayout: LAYOUTS.SLIDESHOW,
   enableInfiniteScroll: true,
-  allowHover: false
+  allowHover: false,
+  //params from layoutHelper
+  showArrows: true,
+  cubeImages: true,
+  smartCrop: false,
+  cubeRatio: '100%/100%',
+  isVertical: false,
+  gallerySize: 550,
+  galleryType: 'Strips',
+  groupSize: 1,
+  groupTypes: '1',
+  fixedColumns: 1,
+  oneRow: true,
+  hasThumbnails: false,
+  enableScroll: true,
+  scrollSnap: true,
+  isGrid: false,
+  isColumns: false,
+  isMasonry: false,
+  isSlider: false,
+  isSlideshow: true,
+  cropOnlyFill: false,
+  floatingImages: 0,
+  galleryMargin: 0,
+  imageMargin: 0,
 }
 export default class SlideshowGallery extends React.Component {
   render() {

--- a/packages/gallery/src/components/gallery/presets/slideshowGallery.js
+++ b/packages/gallery/src/components/gallery/presets/slideshowGallery.js
@@ -6,7 +6,8 @@ export const fixedStyles = {
   galleryLayout: LAYOUTS.SLIDESHOW,
   enableInfiniteScroll: true,
   allowHover: false,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: true,
   cubeImages: true,
   smartCrop: false,

--- a/packages/gallery/src/components/gallery/presets/slideshowGallery.js
+++ b/packages/gallery/src/components/gallery/presets/slideshowGallery.js
@@ -45,9 +45,9 @@ export default class SlideshowGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/slideshowGallery.js
+++ b/packages/gallery/src/components/gallery/presets/slideshowGallery.js
@@ -33,13 +33,20 @@ export const fixedStyles = {
   imageMargin: 0,
 }
 export default class SlideshowGallery extends React.Component {
+
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
+
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
+++ b/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
@@ -33,13 +33,19 @@ export const fixedStyles = {
   imageMargin: 0,
 }
 export default class ThumbnailGallery extends React.Component {
+
+  createStyles = () => {
+    return {
+      ...this.props.styles,
+      ...fixedStyles,
+    }
+  }
   render() {
     return (
       <ProGallery
         {...this.props}
         styles={{
-          ...this.props.styles,
-          ...fixedStyles
+          ...this.createStyles(),
         }}
       />
     );

--- a/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
+++ b/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
@@ -7,7 +7,8 @@ import dimensionsHelper from '../../helpers/dimensionsHelper';
 export const fixedStyles = {
   galleryLayout: LAYOUTS.THUMBNAIL,
   enableInfiniteScroll: true,
-  //params from layoutHelper
+  
+  //this params were moved from the presets in layoutHelper and were not tested and checked yet.
   showArrows: true,
   cubeImages: true,
   smartCrop: false,

--- a/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
+++ b/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
@@ -44,9 +44,9 @@ export default class ThumbnailGallery extends React.Component {
     return (
       <ProGallery
         {...this.props}
-        styles={{
-          ...this.createStyles(),
-        }}
+        styles={
+          this.createStyles()
+        }
       />
     );
   }

--- a/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
+++ b/packages/gallery/src/components/gallery/presets/thumbnailGallery.js
@@ -2,21 +2,45 @@
 import React from 'react';
 import ProGallery from '../proGallery/proGallery';
 import LAYOUTS from '../../../common/constants/layout';
+import dimensionsHelper from '../../helpers/dimensionsHelper';
 
 export const fixedStyles = {
   galleryLayout: LAYOUTS.THUMBNAIL,
-  enableInfiniteScroll: true
+  enableInfiniteScroll: true,
+  //params from layoutHelper
+  showArrows: true,
+  cubeImages: true,
+  smartCrop: false,
+  cubeRatio: '100%/100%',
+  isVertical: false,
+  galleryType: 'Strips',
+  groupSize: 1,
+  gallerySize: () => dimensionsHelper.getGalleryWidth(),
+  groupTypes: '1',
+  oneRow: true,
+  hasThumbnails: true,
+  enableScroll: true,
+  scrollSnap: true,
+  isGrid: false,
+  isSlider: false,
+  isMasonry: false,
+  isColumns: false,
+  isSlideshow: false,
+  cropOnlyFill: false,
+  floatingImages: 0,
+  galleryMargin: 0,
+  imageMargin: 0,
 }
 export default class ThumbnailGallery extends React.Component {
-    render() {
-        return (
-            <ProGallery
-                {...this.props}
-                styles={{
-                    ...this.props.styles,
-                    ...fixedStyles
-                }}
-            />
-        );
-    }
+  render() {
+    return (
+      <ProGallery
+        {...this.props}
+        styles={{
+          ...this.props.styles,
+          ...fixedStyles
+        }}
+      />
+    );
+  }
 }

--- a/packages/gallery/src/components/gallery/proGallery/proGallery.js
+++ b/packages/gallery/src/components/gallery/proGallery/proGallery.js
@@ -26,7 +26,7 @@ export default class ProGallery extends GalleryComponent {
     if (typeof props.viewMode !== 'undefined') {
       viewModeWrapper.setViewMode(props.viewMode);
     }
-    this.domId = props.domId || Math.floor(Math.random() * 10000);
+    // this.domId = props.domId || Math.floor(Math.random() * 10000);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -38,10 +38,10 @@ export default class ProGallery extends GalleryComponent {
   render() {
     return (
       this.canRender && (
-        <div id={`pro-gallery-${this.domId}`} className="pro-gallery">
+        <div id={`pro-gallery-${this.props.domId}`} className="pro-gallery">
           <GalleryContainer
             {...this.props}
-            domId={this.domId}
+            domId={this.props.domId}
             items={this.props.items || []}
             watermarkData={this.props.watermarkData}
             settings={this.props.settings || {}}

--- a/packages/gallery/src/components/gallery/proGallery/proGallery.js
+++ b/packages/gallery/src/components/gallery/proGallery/proGallery.js
@@ -26,7 +26,6 @@ export default class ProGallery extends GalleryComponent {
     if (typeof props.viewMode !== 'undefined') {
       viewModeWrapper.setViewMode(props.viewMode);
     }
-    // this.domId = props.domId || Math.floor(Math.random() * 10000);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/packages/gallery/src/components/helpers/layoutHelper.js
+++ b/packages/gallery/src/components/helpers/layoutHelper.js
@@ -248,6 +248,8 @@ function getStyleByGalleryType(styles) {
 }
 export const getPreset = (styles) => {
   const { gallerySize, magicLayoutSeed } = styles;
+  console.log(dimensionsHelper.getGalleryHeight());
+  
   return {
     collage: () => ({
       showArrows: false,
@@ -326,26 +328,30 @@ export const getPreset = (styles) => {
       galleryMargin: 0,
       imageMargin: 0,
     }),
-    slider: () => ({
-      showArrows: true,
-      cubeImages: true,
-      smartCrop: false,
-      isVertical: false,
-      galleryType: 'Strips',
-      groupSize: 1,
-      groupTypes: '1',
-      gallerySize: () => dimensionsHelper.getGalleryHeight(),
-      oneRow: true,
-      hasThumbnails: false,
-      enableScroll: true,
-      scrollSnap: true,
-      isGrid: false,
-      isSlider: true,
-      isColumns: false,
-      isMasonry: false,
-      isSlideshow: false,
-      cropOnlyFill: true,
-    }),
+    slider: () => {
+      // console.log(dimensionsHelper.getGalleryHeight());
+      return {
+        // gallerySize: () => dimensionsHelper.getGalleryHeight(),
+      }
+      // showArrows: true,
+      // cubeImages: true,
+      // smartCrop: false,
+      // isVertical: false,
+      // galleryType: 'Strips',
+      // groupSize: 1,
+      // groupTypes: '1',
+      // gallerySize: () => dimensionsHelper.getGalleryHeight(),
+      // oneRow: true,
+      // hasThumbnails: false,
+      // enableScroll: true,
+      // scrollSnap: true,
+      // isGrid: false,
+      // isSlider: true,
+      // isColumns: false,
+      // isMasonry: false,
+      // isSlideshow: false,
+      // cropOnlyFill: true,
+    },
     slideshow: () => ({
       showArrows: true,
       cubeImages: true,

--- a/packages/gallery/src/components/helpers/layoutHelper.js
+++ b/packages/gallery/src/components/helpers/layoutHelper.js
@@ -217,6 +217,17 @@ function addLayoutStyles(styles) {
     if (utils.isVerbose()) {
       console.log('Using galleryLayout for defaults', styles);
     }
+
+    // in case of galleryLayoutv2 is defind but layout does not exist, default to collage .
+    const layoutName = getLayoutName(Number(styles.galleryLayout));
+    if (utils.isUndefined(layoutName) || styles.galleryLayout === '') {
+      styles = Object.assign({}, emptyLayout, styles,
+        {
+          ...NEW_PRESETS.collage,
+          gallerySize: Math.round(30 * 5 + 500)
+        });
+    }
+
     styles = Object.assign({}, emptyLayout, styles); //legacy layouts
     const selectedLayoutVars = [
       'galleryLayout',

--- a/packages/gallery/src/components/helpers/layoutHelper.js
+++ b/packages/gallery/src/components/helpers/layoutHelper.js
@@ -228,7 +228,7 @@ function addLayoutStyles(styles) {
         });
     }
 
-    styles = Object.assign({}, emptyLayout, styles); //legacy layouts
+    styles = Object.assign({}, emptyLayout, styles);
     const selectedLayoutVars = [
       'galleryLayout',
       'galleryThumbnailsAlignment',

--- a/packages/gallery/src/components/helpers/layoutHelper.js
+++ b/packages/gallery/src/components/helpers/layoutHelper.js
@@ -6,7 +6,6 @@ import GALLERY_SIZE_TYPE from '../../common/constants/gallerySizeType';
 import window from '../../common/window/windowWrapper';
 import { featureManager } from './versionsHelper';
 import dimensionsHelper from './dimensionsHelper';
-import { getFixedLayouts } from './fixedLayoutsHelper';
 import designConsts from '../../common/constants/designConsts';
 import INFO_TYPE from '../../common/constants/infoType';
 import CALCULATION_OPTIONS from '../../common/constants/calculationOptions';

--- a/packages/gallery/src/components/helpers/layoutHelper.js
+++ b/packages/gallery/src/components/helpers/layoutHelper.js
@@ -44,88 +44,6 @@ const emptyLayout = {
   enableInfiniteScroll: undefined,
 };
 
-function getStyleBySeed(seed) {
-  if (!seed > 0) {
-    seed = 999999;
-  }
-  seed = Math.floor(seed);
-
-  const strToSeed = str => {
-    str = String(str);
-    let total = 0;
-    for (let s = 0; s < str.length; s++) {
-      total += str.charCodeAt(s);
-    }
-    return total;
-  };
-
-  const mergeSeeds = (s1, s2) => {
-    return Math.floor((s1 / s2 - Math.floor(s1 / s2)) * 10000000);
-  };
-
-  const numFromSeed = (min, max, strSeed) => {
-    const seed2 = strToSeed(strSeed);
-    const range = max - min + 1;
-    return (mergeSeeds(seed, seed2) % range) + min;
-  };
-
-  const boolFromSeed = strSeed => {
-    return !!numFromSeed(0, 1, strSeed);
-  };
-
-  const style = {
-    cubeImages: boolFromSeed('cubeImages'),
-    cubeRatio: numFromSeed(1, 25, 'cubeRatio') / 5,
-    isVertical: boolFromSeed('isVertical'),
-    gallerySize: numFromSeed(300, 800, 'gallerySize'),
-    collageAmount: numFromSeed(5, 10, 'collageAmount') / 10,
-    collageDensity:
-      (featureManager.supports.spacingCalculation
-        ? numFromSeed(1, 100, 'collageDensity')
-        : numFromSeed(5, 10, 'collageDensity')) / 100,
-    groupTypes: ['1'].concat(
-      ('2h,2v,3t,3b,3l,3r,3h,3v').split(',').filter((type, i) =>
-        boolFromSeed('groupTypes' + i),
-      ),
-    ),
-    oneRow: boolFromSeed('oneRow'),
-    imageMargin: numFromSeed(
-      0,
-      featureManager.supports.spacingCalculation
-        ? numFromSeed(300, 800, 'gallerySize') / 5
-        : 5,
-      'imageMargin',
-    ),
-    galleryMargin: featureManager.supports.spacingCalculation
-      ? 0
-      : numFromSeed(0, 5, 'imageMargin'),
-    floatingImages: 0,
-    chooseBestGroup: boolFromSeed('chooseBestGroup'),
-    smartCrop: boolFromSeed('smartCrop'),
-    showArrows: false,
-    cubeType: 'fill',
-    hasThumbnails: false,
-    enableScroll: true,
-    isGrid: false,
-    isSlideshow: false,
-    isSlider: false,
-    isColumns: false,
-    cropOnlyFill: false,
-    fixedColumns: 0,
-    enableInfiniteScroll: 1,
-  };
-
-  //force adjustments
-  if (style.oneRow) {
-    style.isVertical = false;
-  }
-  style.galleryType = style.isVertical ? 'Columns' : 'Strips';
-  style.groupSize = parseInt(style.groupTypes.slice(-1)[0]);
-  style.groupTypes = style.groupTypes.join(',');
-  style.minItemSize = style.gallerySize / style.groupSize / 2;
-
-  return style;
-}
 
 function getStyleByGalleryType(styles) {
   //legacy layouts
@@ -246,220 +164,11 @@ function getStyleByGalleryType(styles) {
 
   return styleState;
 }
-export const getPreset = (styles) => {
-  const { gallerySize, magicLayoutSeed } = styles;
-  console.log(dimensionsHelper.getGalleryHeight());
-  
-  return {
-    collage: () => ({
-      showArrows: false,
-      cubeImages: false,
-      groupSize: 3,
-      groupTypes: '1,2h,2v,3t,3b,3l,3r',
-      gallerySize: Math.round(gallerySize * 5 + 500),
-      fixedColumns: 0,
-      hasThumbnails: false,
-      enableScroll: true,
-      isGrid: false,
-      isSlider: false,
-      isMasonry: false,
-      isColumns: false,
-      isSlideshow: false,
-      cropOnlyFill: false,
-    }),
-    masonry: () => ({
-      showArrows: false,
-      cubeImages: false,
-      groupSize: 1,
-      groupTypes: '1',
-      gallerySize,
-      fixedColumns: 0,
-      hasThumbnails: false,
-      enableScroll: true,
-      isGrid: false,
-      isSlider: false,
-      isMasonry: true,
-      isColumns: false,
-      isSlideshow: false,
-      cropOnlyFill: false,
-      oneRow: false,
-    }),
-    grid: () => ({
-      showArrows: false,
-      cubeImages: true,
-      smartCrop: false,
-      isVertical: true,
-      galleryType: 'Columns',
-      groupSize: 1,
-      groupTypes: '1',
-      fixedColumns: undefined,
-      gallerySize: Math.round(gallerySize * 8.5 + 150),
-      hasThumbnails: false,
-      enableScroll: true,
-      cropOnlyFill: false,
-      isSlider: false,
-      isColumns: false,
-      isGrid: true,
-      isMasonry: false,
-      isSlideshow: false,
-      minItemSize: 50,
-    }),
-    thumbnails: () => ({
-      showArrows: true,
-      cubeImages: true,
-      smartCrop: false,
-      cubeRatio: '100%/100%',
-      isVertical: false,
-      galleryType: 'Strips',
-      groupSize: 1,
-      gallerySize: () => dimensionsHelper.getGalleryWidth(),
-      groupTypes: '1',
-      oneRow: true,
-      hasThumbnails: true,
-      enableScroll: true,
-      scrollSnap: true,
-      isGrid: false,
-      isSlider: false,
-      isMasonry: false,
-      isColumns: false,
-      isSlideshow: false,
-      cropOnlyFill: false,
-      floatingImages: 0,
-      galleryMargin: 0,
-      imageMargin: 0,
-    }),
-    slider: () => {
-      // console.log(dimensionsHelper.getGalleryHeight());
-      return {
-        // gallerySize: () => dimensionsHelper.getGalleryHeight(),
-      }
-      // showArrows: true,
-      // cubeImages: true,
-      // smartCrop: false,
-      // isVertical: false,
-      // galleryType: 'Strips',
-      // groupSize: 1,
-      // groupTypes: '1',
-      // gallerySize: () => dimensionsHelper.getGalleryHeight(),
-      // oneRow: true,
-      // hasThumbnails: false,
-      // enableScroll: true,
-      // scrollSnap: true,
-      // isGrid: false,
-      // isSlider: true,
-      // isColumns: false,
-      // isMasonry: false,
-      // isSlideshow: false,
-      // cropOnlyFill: true,
-    },
-    slideshow: () => ({
-      showArrows: true,
-      cubeImages: true,
-      smartCrop: false,
-      cubeRatio: '100%/100%',
-      isVertical: false,
-      gallerySize: 550,
-      galleryType: 'Strips',
-      groupSize: 1,
-      groupTypes: '1',
-      fixedColumns: 1,
-      oneRow: true,
-      hasThumbnails: false,
-      enableScroll: true,
-      scrollSnap: true,
-      isGrid: false,
-      isColumns: false,
-      isMasonry: false,
-      isSlider: false,
-      isSlideshow: true,
-      cropOnlyFill: false,
-      floatingImages: 0,
-      galleryMargin: 0,
-      imageMargin: 0,
-    }),
-    panorama: () => ({
-      showArrows: false,
-      cubeImages: false,
-      isVertical: true,
-      galleryType: 'Columns',
-      groupSize: 1,
-      groupTypes: '1',
-      gallerySize: () => dimensionsHelper.getGalleryWidth(),
-      oneRow: false,
-      fixedColumns: 1,
-      hasThumbnails: false,
-      enableScroll: true,
-      isGrid: false,
-      isColumns: false,
-      isMasonry: false,
-      isSlider: false,
-      isSlideshow: false,
-      cropOnlyFill: false,
-      slideshowLoop: false,
-    }),
-    column: () => ({
-      showArrows: true,
-      cubeImages: true,
-      smartCrop: false,
-      cubeType: 'fill',
-      cubeRatio: 0.35,
-      isVertical: false,
-      galleryType: 'Strips',
-      groupSize: 1,
-      groupTypes: '1',
-      gallerySize: () => dimensionsHelper.getGalleryHeight(),
-      fixedColumns: 0,
-      hasThumbnails: false,
-      oneRow: true,
-      enableScroll: true,
-      isGrid: false,
-      isColumns: true,
-      isMasonry: false,
-      isSlider: false,
-      isSlideshow: false,
-      cropOnlyFill: false,
-    }),
-    fullsize: () => ({
-      showArrows: true,
-      cubeImages: true,
-      smartCrop: false,
-      cubeType: 'fill',
-      cubeRatio: '100%/100%',
-      isVertical: false,
-      galleryType: 'Strips',
-      groupSize: 1,
-      gallerySize: () => dimensionsHelper.getGalleryWidth(),
-      groupTypes: '1',
-      oneRow: true,
-      hasThumbnails: false,
-      enableScroll: true,
-      scrollSnap: true,
-      isGrid: false,
-      isSlider: false,
-      isColumns: false,
-      isMasonry: false,
-      isSlideshow: false,
-      cropOnlyFill: false,
-      floatingImages: 0,
-      galleryMargin: 0,
-      imageMargin: 0,
-    }),
-    empty: () => ({
-      gallerySize: Math.round(gallerySize * 9 + 100),
-    }),
-    magic: () => getStyleBySeed(magicLayoutSeed),
-    bricks: () => getFixedLayouts(0),
-    alternate: () => getFixedLayouts(1),
-    mix: () => getFixedLayouts(2),
-  };
-}
 
 //returns true if the given param is in the current layout preset
 export const isInPreset = (styleParams, paramToCheck) => {
-  const layoutName = getLayoutName(styleParams.galleryLayout + 1) || 'empty';// empty for when there is no layout given
-  const oldPresets = getPreset(styleParams);
-  return Object.keys(oldPresets[layoutName]()).includes(paramToCheck) ||
-  Object.keys(NEW_PRESETS[layoutName]).includes(paramToCheck);
+  const layoutName = getLayoutName(styleParams.galleryLayout) || 'empty';// empty for when there is no layout given
+  return Object.keys(NEW_PRESETS[layoutName]).includes(paramToCheck);
 }
 
 const getLayoutName = (galleryLayout) => {
@@ -479,26 +188,7 @@ const getLayoutName = (galleryLayout) => {
     'alternate', // 11
     'mix', // 12
   ];
-  return galleyLayoutList[galleryLayout]
-}
-function getStyleByLayout(styles) {
-  //new layouts
-  let { galleryLayout } = styles;
-  let layoutName = getLayoutName(galleryLayout + 1); //the empty layout is -1, collage is 0 etc.
-  
-  if (utils.isUndefined(layoutName)) {
-    galleryLayout = 0;
-    layoutName = 'collage';
-  }
-
-  if (utils.isVerbose()) {
-    console.log('chosen layout is', layoutName);
-  }
-  const layouts = getPreset(styles)
-  return {
-    ...layouts[layoutName](),
-    galleryLayout
-  };
+  return galleyLayoutList[galleryLayout + 1]
 }
 
 function addLayoutStyles(styles) {
@@ -527,7 +217,7 @@ function addLayoutStyles(styles) {
     if (utils.isVerbose()) {
       console.log('Using galleryLayout for defaults', styles);
     }
-    styles = Object.assign({}, emptyLayout, styles, getStyleByLayout(styles)); //legacy layouts
+    styles = Object.assign({}, emptyLayout, styles); //legacy layouts
     const selectedLayoutVars = [
       'galleryLayout',
       'galleryThumbnailsAlignment',

--- a/packages/gallery/tests/drivers/mocks/stylesImportMock.js
+++ b/packages/gallery/tests/drivers/mocks/stylesImportMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/gallery/tests/drivers/reactDriver.js
+++ b/packages/gallery/tests/drivers/reactDriver.js
@@ -9,7 +9,8 @@ import React from 'react';
 import utils from '../../src/common/utils';
 import window from '../../src/common/window/windowWrapper';
 import Adapter from 'enzyme-adapter-react-16';
-import ProGallery from '../../src/components/gallery/proGallery/proGallery';
+import ProGallery from '../../src/components/gallery/index.js';
+
 
 configure({ adapter: new Adapter() });
 

--- a/packages/gallery/tests/drivers/reactDriver.js
+++ b/packages/gallery/tests/drivers/reactDriver.js
@@ -9,7 +9,7 @@ import React from 'react';
 import utils from '../../src/common/utils';
 import window from '../../src/common/window/windowWrapper';
 import Adapter from 'enzyme-adapter-react-16';
-import ProGallery from '../../src/components/gallery/index.js';
+import ProGallery from '../../src/components/gallery';
 
 
 configure({ adapter: new Adapter() });


### PR DESCRIPTION
Refactored the function that set styles by layouts (getStyleByLayout in layoutHelper) and moved the fixed styles to the correct preset in src/components/gallery/presets folder.
Added missing preset ('empty' layout) in the presets folder.