### PR TITLE
Fix Pass customImageRenderer to ViewComponent

### DIFF
--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -2,7 +2,7 @@
   "publishScoped": false,
   "private": false,
   "name": "pro-gallery",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "sideEffects": [
     "./src/components/styles/gallery.scss"
   ],

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainerNew.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainerNew.js
@@ -1066,6 +1066,7 @@ export class GalleryContainer extends React.Component {
           domId={this.props.domId}
           currentIdx={this.props.currentIdx || 0}
           customHoverRenderer={this.props.customHoverRenderer}
+          customImageRenderer={this.props.customImageRenderer}
           customInfoRenderer={this.props.customInfoRenderer}
           customSlideshowInfoRenderer={this.props.customSlideshowInfoRenderer}
           customNavArrowsRenderer={this.props.customNavArrowsRenderer}


### PR DESCRIPTION
Passing `customImageRenderer` like indicated in the docs doesn't seem to work, after passing it to the `ViewComponent` it works

Usage example:

```javascript
<ProGallery
  items={items}
  options={options}
  container={{
    width,
    height,
  }}
  eventsListener={eventsListener}
  scrollingElement={scrollingElement}
  customImageRenderer={customImageRenderer}
/>
  ```