### PR TITLE
Debug actual source code

### DIFF
--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -23,7 +23,7 @@
     "watch": "npm run start",
     "start": "tsc -w && npm run css-watch",
     "build": "tsc && tsc -p tsconfig-esm.json && npm run css-compile",
-    "build:dev": "tsc && tsc -p tsconfig-esm-dev.json && npm run css-compile",
+    "start:dev": "npm run css-compile && tsc && tsc -w -p tsconfig-esm-dev.json",
     "css-compile": "sass --style expanded --source-map --embed-sources --no-error-css src/components/styles/gallery.scss:dist/statics/main.css",
     "css-watch": "sass --watch src/components/styles/gallery.scss:dist/statics/main.css",
     "test": "jest --testPathIgnorePatterns '.*/e2e/.*.e2e.spec.js' --silent",

--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -23,6 +23,7 @@
     "watch": "npm run start",
     "start": "tsc -w && npm run css-watch",
     "build": "tsc && tsc -p tsconfig-esm.json && npm run css-compile",
+    "build:dev": "tsc && tsc -p tsconfig-esm-dev.json && npm run css-compile",
     "css-compile": "sass --style expanded --source-map --embed-sources --no-error-css src/components/styles/gallery.scss:dist/statics/main.css",
     "css-watch": "sass --watch src/components/styles/gallery.scss:dist/statics/main.css",
     "test": "jest --testPathIgnorePatterns '.*/e2e/.*.e2e.spec.js' --silent",

--- a/packages/gallery/tsconfig-esm-dev.json
+++ b/packages/gallery/tsconfig-esm-dev.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.json",
+  "compilerOptions": {
+    "target": "ES2017"
+  }
+}


### PR DESCRIPTION
### Why?
We work on open source code so I want to be able to debug it with the same experience that the create-react-app is offering. 
There were two things that bothered me before this PR:

1. When I ran `npm run start` the react-app I had linked to the `pro-gallery` didn't auto refresh on changes.
2. I could only debug the es5 version in the browser, which made it much difficult (screenshot attached)

![es5progallery](https://user-images.githubusercontent.com/1308961/117139253-b35f0700-adb4-11eb-8df4-8820dfe2d98a.png)



### What? 

1. Adding a separate configuration file to target `es2017` for dev purposes.
2. Adding `start:dev` which keeps the watch flag at the end of the command

The result is in the gif attached: the react app is auto-refreshing and the source code I debug is the same as the one in my text editor


![progallerywatchmodees2017](https://user-images.githubusercontent.com/1308961/117139374-d984a700-adb4-11eb-8887-050063ea38ed.gif)



