### PR TITLE
Images from web

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,83 @@ yarn add pro-gallery
 ```jsx
 import { ProGallery } from 'pro-gallery';
 import 'pro-gallery/dist/statics/main.css';
+export default function Gallery() {
+	// Add your images here...
+	const items = [
+		{ // Image item:
+			itemId: 'sample-id',
+			mediaUrl: 'https://i.picsum.photos/id/674/200/300.jpg?hmac=kS3VQkm7AuZdYJGUABZGmnNj_3KtZ6Twgb5Qb9ITssY',
+			metaData: {
+				type: 'image',
+				height: 200,
+				width: 100,
+				title: 'sample-title',
+				description: 'sample-description',
+				focalPoint: [0, 0],
+				link: {
+					url: 'http://example.com',
+					target: '_blank'
+				},
+			}
+		},
+		{ // Another Image item:
+			itemId: 'differentItem',
+			mediaUrl: 'https://i.picsum.photos/id/1003/1181/1772.jpg?hmac=oN9fHMXiqe9Zq2RM6XT-RVZkojgPnECWwyEF1RvvTZk',
+			metaData: {
+				type: 'image',
+				height: 200,
+				width: 100,
+				title: 'sample-title',
+				description: 'sample-description',
+				focalPoint: [0, 0],
+				link: {
+					url: 'http://example.com',
+					target: '_blank'
+				},
+			}
+		},
+		{ // HTML item:
+			itemId: 'htmlItem',
+			html: "<div style='width: 300px; height: 200px; background:pink;'>I am a text block</div>",
+			metadata: {
+				type: "text",
+				height: 200,
+				width: 300,
+				title: 'sample-title',
+				description: 'sample-description',
+				backgroundColor: 'pink'
+			},
 
-<ProGallery
-  domId={domId}
-  items={items}
-  options={options}
-  container={container}
-  scrollingElement={() => document.getElementById('gallery') || window}
-  eventsListener={(eName, eData) => console.log({eName, eData})}
-  resizeMediaUrl={(item, url, resizeMethod, width, height) => `https://...`}
-  isPrerenderMode={isPrerenderMode}
-/>
+		},
+	]
+
+	// The options of the gallery (from the playground current state)
+	const options = {
+		galleryLayout: -1,
+	};
+
+	// The size of the gallery container. The images will fit themselves in it
+	const container = {
+		width: window.innerWidth,
+		height: window.innerHeight
+	};
+
+	// The eventsListener will notify you anytime something has happened in the gallery.
+	const eventsListener = (eventName, eventData) => console.log({eventName, eventData}); 
+
+	// The scrollingElement is usually the window, if you are scrolling inside another element, suplly it here
+	const scrollingElement = window;
+
+	return (
+		<ProGallery
+			items={items}
+			options={options}
+			container={container}
+			eventsListener={eventsListener}
+			scrollingElement={scrollingElement}
+		/>
+	);
+}
 ```
 
 To see more options and a real usage example, use the [playground source code](https://github.com/wix/pro-gallery/blob/master/packages/playground/src/components/App/App.js) as reference.
@@ -51,60 +117,6 @@ To see more options and a real usage example, use the [playground source code](h
 The gallery has A LOT of options, so to make it all easier, we created the [Playground](https://pro-gallery.surge.sh). Each option is expandable in the sidebar, and has all the info you need about using it.
 Notice that you can click on `Generate Gallery Code` anytime to get the code for the gallery layout you created.
 
-### Items
-For the code you generated to work you need to do just one more thing - provide it with a list of objects, each containing at least an id, dto, and metadata:
-```jsx
-const items = [
-  { // Image item:
-    itemId: 'sample-id',
-    mediaUrl: 'sample-image-url',
-    metaData: {
-      type: 'image',
-      height: 200,
-      width: 100,
-      title: 'sample-title',
-      description: 'sample-description',
-      focalPoint: [0, 0],
-      link: {
-        url: 'http://example.com',
-        target: '_blank'
-      },
-    }
-  },
-  { // Video item:
-    itemId: 'sample-id',
-    mediaUrl: 'sample-video-url',
-    metaData: {
-      type: 'video',
-      height: 200,
-      width: 100,
-  		poster: 'sample-image-url',
-      title: 'sample-title',
-      description: 'sample-description',
-      focalPoint: [0, 0],
-      link: {
-        url: 'http://example.com',
-        target: '_blank'
-      },
-    }
-  },
-  { // HTML item:
-    itemId: 'sample-id',
-    html: "<div style='width: 300px; height: 200px; background:pink;'>I am a text block</div>",
-    metadata: {
-      type: "text",
-      height: 200,
-      width: 300,
-      title: 'sample-title',
-      description: 'sample-description',
-      backgroundColor: 'pink'
-    },
-
-  },
-  {...},
-  {...}
-]
-```
 
 ### Container
 An object containing the width and height (in pixels) of the gallery.

--- a/packages/playground/src/components/CodePanel/CodePanel.js
+++ b/packages/playground/src/components/CodePanel/CodePanel.js
@@ -73,7 +73,54 @@ function getCode(options) {
   export function Gallery() {
 
     // Add your images here...
-    const items = [];
+    const items = [
+            { // Image item:
+                    itemId: 'sample-id',
+                    mediaUrl: 'https://i.picsum.photos/id/674/200/300.jpg?hmac=kS3VQkm7AuZdYJGUABZGmnNj_3KtZ6Twgb5Qb9ITssY',
+                    metaData: {
+                            type: 'image',
+                            height: 200,
+                            width: 100,
+                            title: 'sample-title',
+                            description: 'sample-description',
+                            focalPoint: [0, 0],
+                            link: {
+                                    url: 'http://example.com',
+                                    target: '_blank'
+                            },
+                    }
+            },
+            { // Another Image item:
+                    itemId: 'differentItem',
+                    mediaUrl: 'https://i.picsum.photos/id/1003/1181/1772.jpg?hmac=oN9fHMXiqe9Zq2RM6XT-RVZkojgPnECWwyEF1RvvTZk',
+                    metaData: {
+                            type: 'image',
+                            height: 200,
+                            width: 100,
+                            title: 'sample-title',
+                            description: 'sample-description',
+                            focalPoint: [0, 0],
+                            link: {
+                                    url: 'http://example.com',
+                                    target: '_blank'
+                            },
+                    }
+            },
+            { // HTML item:
+                    itemId: 'htmlItem',
+                    html: "<div style='width: 300px; height: 200px; background:pink;'>I am a text block</div>",
+                    metadata: {
+                            type: "text",
+                            height: 200,
+                            width: 300,
+                            title: 'sample-title',
+                            description: 'sample-description',
+                            backgroundColor: 'pink'
+                    },
+
+            },
+    ]
+
 
     // The options of the gallery (from the playground current state)
     const options = {


### PR DESCRIPTION
### Why?
When a user copy pastes code from documentation and it doesn't work out of the box - he is leaving to search for something that works. We will always want our users to start from a **working state**, and then gradually configure and expand their use. But they should always start from the happy flow of a working gallery

### What?

1. Use default items from the web in the playground code generator
2. Do the same on the README.md of the root
3. Remove the video samples beacuse they are dependent on a `resizeMediaUrl` functionality.