### PR TITLE
18 may auto slide pause on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
  
 #### GALLERY
  -  improve: changed 'ITEM_FOCUS' and 'ITEM_LOST_FOCUS' parameters
- -  base ts behaviour
+ -  base ts behavior
 
 #### OTHER
  - v3.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
  
 #### GALLERY
  -  improve: changed 'ITEM_FOCUS' and 'ITEM_LOST_FOCUS' parameters
- -  base ts behavior
+ -  base ts behaviour
 
 #### OTHER
  - v3.1.11

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -727,6 +727,8 @@ export class GalleryContainer extends React.Component {
         className={this.props.isPrerenderMode ? 'pro-gallery-prerender' : ''}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
+        ref={e => this.galleryContainerRef = e}
+        tabIndex={-1}
       >
         <ScrollIndicator
           domId={this.props.domId}
@@ -769,6 +771,7 @@ export class GalleryContainer extends React.Component {
           proGalleryRegionLabel={this.props.proGalleryRegionLabel}
           firstUserInteractionExecuted={this.state.firstUserInteractionExecuted}
           isGalleryInHover={this.state.isInHover}
+          galleryContainerRef={this.galleryContainerRef}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -16,6 +16,15 @@ import { GalleryComponent } from '../../galleryComponent';
 import TextItem from '../../item/textItem.js';
 
 const SKIP_SLIDES_MULTIPLIER = 1.5;
+
+function getDirection(code) {
+  const reverse = [33, 37, 38]
+  const direct = [32, 34, 39, 40]
+  if (reverse.includes(code)) return -1
+  else if (direct.includes(code)) return 1
+  throw new Error(`no direction is defined for charCode: ${code}`)
+}
+
 class SlideshowView extends GalleryComponent {
   constructor(props) {
     super(props);
@@ -449,27 +458,18 @@ class SlideshowView extends GalleryComponent {
 
   handleSlideshowKeyPress(e) {
     e.stopPropagation();
-    switch (e.charCode || e.keyCode) {
-      case 38: //up
-      case 37: //left
-      case 33: //page up
-        e.preventDefault();
-        this._next({ direction: -1, isKeyboardNavigation: true });
-        return false;
-      case 39: //right
-      case 40: //down
-      case 32: //space
-      case 34: //page down
-        e.preventDefault();
-        this._next({ direction: 1, isKeyboardNavigation: true });
-        return false;
-      case 27: // esc
-      if(this.props.galleryContainerRef) {
-        this.props.galleryContainerRef.focus();
-      }
+    const nextKeys = [32, 33, 34, 37, 38, 39, 40]
+    const code = e.charCode || e.keyCode
+
+    if (nextKeys.includes(code)) {
+      e.preventDefault();
+      this._next({ direction: getDirection(code), isKeyboardNavigation: true });
+      return false;
+    } else if (code === 27 && this.props.galleryContainerRef) {
+      this.props.galleryContainerRef.focus()
       return false;
     }
-    return true; //continue handling the original keyboard event
+    return true
   }
 
   createThumbnails(thumbnailPosition) {

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -231,7 +231,7 @@ class SlideshowView extends GalleryComponent {
         avoidIndividualNavigation &&
         !(this.props.styleParams.groupSize > 1)
       ) {
-        currentIdx = this.getCenteredItemIdxByScroll();
+        currentIdx = this.getCenteredItemIdxByScroll(); 
       } else {
         currentIdx = isAutoTrigger
           ? this.setCurrentItemByScroll()
@@ -459,6 +459,8 @@ class SlideshowView extends GalleryComponent {
   handleSlideshowKeyPress(e) {
     e.stopPropagation();
     const nextKeys = [32, 33, 34, 37, 38, 39, 40]
+    // key code -> 32=space, 37=left, 38=up, 39=right, 40=down
+    // charCode -> , 33=page up, 34=page down
     const code = e.charCode || e.keyCode
 
     if (nextKeys.includes(code)) {

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1312,15 +1312,22 @@ class SlideshowView extends GalleryComponent {
 
   blockAutoSlideshowIfNeeded(props = this.props) {
     const { isGalleryInHover, styleParams } = props;
-    const { pauseAutoSlideshowClicked, shouldBlockAutoSlideshow, isInView,isInFocus } =
+    const { pauseAutoSlideshowClicked, shouldBlockAutoSlideshow, isInView, isInFocus } =
       this.state;
     let should = false;
     if (!isInView || pauseAutoSlideshowClicked) {
       should = true;
     } else if (
+      isGalleryInHover &&
       styleParams.pauseAutoSlideshowOnHover
     ) {
-      should = isGalleryInHover || isInFocus && styleParams.isAccessible;
+      should = true;
+    } else if (
+      isInFocus &&
+      styleParams.pauseAutoSlideshowOnHover &&
+      styleParams.isAccessible
+    ) {
+      should = true;
     }
     if (shouldBlockAutoSlideshow !== should) {
       this.setState({ shouldBlockAutoSlideshow: should }, () => {


### PR DESCRIPTION
On A11Y mode only :
On horizontal layouts + auto slide-
When the user is in focus mode (a11y) on one of these elements 
Item (video, image, text item) 
Buttons
Navigation Arrows 
then, the auto slide should pause (just like a pause on hover). 

When the user press Esc and the focus go to the gallery container, the auto slide should run again. 