### PR TITLE
fix video center alignment when in a tall container

### DIFF
--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -149,7 +149,7 @@ class VideoItem extends GalleryComponent {
     // adding 1 pixel to compensate for the difference we have sometimes from layouter in grid fill
     const videoDimensionsCss = {
       width: isWiderThenContainer ? 'calc(100% + 1px)' : 'auto',
-      height: isWiderThenContainer ? 'auto' : 'calc(100% + 1px)',
+      height: isWiderThenContainer ? '100%' : 'calc(100% + 1px)',
     };
 
     if (


### PR DESCRIPTION
Why?
videos are acting strange in the new possibilities that presets present.
Container ratios can now be set by the preset and not by the ratio of the item.

How?
changed css to 100% height instead of the auto it had. This does it CCS-wise. 
width acts different than height and doesn't need this tweek.
