### PR TITLE
add keyup event listener to ESC keyCode + remove pauseAutoSlideShowOn…

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -37,6 +37,7 @@ export class GalleryContainer extends React.Component {
     this.setPlayingIdxState = this.setPlayingIdxState.bind(this);
     this.getVisibleItems = this.getVisibleItems.bind(this);
     this.findNeighborItem = this.findNeighborItem.bind(this);
+    this.focusGalleryContainer = this.focusGalleryContainer.bind(this);
     this.setCurrentSlideshowViewIdx =
       this.setCurrentSlideshowViewIdx.bind(this);
     this.getIsScrollLessGallery = this.getIsScrollLessGallery.bind(this);
@@ -547,6 +548,10 @@ export class GalleryContainer extends React.Component {
     });
   }
 
+  focusGalleryContainer(){
+    this.galleryContainerRef.focus();
+  }
+
   toggleLoadMoreItems() {
     this.eventsListener(
       GALLERY_CONSTS.events.LOAD_MORE_CLICKED,
@@ -780,6 +785,7 @@ export class GalleryContainer extends React.Component {
             setWixHeight: () => {},
             scrollToItem: this.scrollToItem,
             scrollToGroup: this.scrollToGroup,
+            focusGalleryContainer: this.focusGalleryContainer,
           }}
           {...this.props.gallery}
         />

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -549,7 +549,9 @@ export class GalleryContainer extends React.Component {
   }
 
   focusGalleryContainer(){
-    this.galleryContainerRef.focus();
+    if(this.galleryContainerRef){
+      this.galleryContainerRef.focus();
+    }
   }
 
   toggleLoadMoreItems() {
@@ -776,7 +778,6 @@ export class GalleryContainer extends React.Component {
           proGalleryRegionLabel={this.props.proGalleryRegionLabel}
           firstUserInteractionExecuted={this.state.firstUserInteractionExecuted}
           isGalleryInHover={this.state.isInHover}
-          galleryContainerRef={this.galleryContainerRef}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -55,12 +55,9 @@ class GalleryView extends GalleryComponent {
           );
           break;
         case 27: //esc
-          if (this.props.galleryContainerRef) {
-            e.stopPropagation();
-            this.props.actions.focusGalleryContainer();
-            return false;
-          }
-          break;
+          e.stopPropagation();
+          this.props.actions.focusGalleryContainer();
+          return false;
       }
 
       //if nextIdx is below the lastVisibleItemIdx (higher idx), we will ignore the findNeighborItem answer and stay on the same item

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -8,7 +8,7 @@ import { GalleryComponent } from '../../galleryComponent';
 class GalleryView extends GalleryComponent {
   constructor(props) {
     super(props);
-    this.handleArrowKeys = this.handleArrowKeys.bind(this);
+    this.handleKeys = this.handleKeys.bind(this);
     this.showMoreItems = this.showMoreItems.bind(this);
     this.createGalleryConfig = this.createGalleryConfig.bind(this);
     this.screenLogs = this.screenLogs.bind(this);
@@ -21,7 +21,7 @@ class GalleryView extends GalleryComponent {
     };
   }
 
-  handleArrowKeys(e) {
+  handleKeys(e) {
     const activeItemIdx =
       window.document.activeElement.getAttribute('data-idx');
 
@@ -53,6 +53,13 @@ class GalleryView extends GalleryComponent {
             idx,
             this.props.styleParams.isRTL ? 'left' : 'right'
           );
+          break;
+        case 27: //esc
+          if (this.props.galleryContainerRef) {
+            e.stopPropagation();
+            this.props.galleryContainerRef.focus();
+            return false;
+          }
           break;
       }
 
@@ -163,7 +170,7 @@ class GalleryView extends GalleryComponent {
           overflowX: 'hidden',
           //  width: this.props.container.galleryWidth,
         }}
-        onKeyDown={this.handleArrowKeys}
+        onKeyDown={this.handleKeys}
       >
         <div
           id="pro-gallery-margin-container"

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -57,7 +57,7 @@ class GalleryView extends GalleryComponent {
         case 27: //esc
           if (this.props.galleryContainerRef) {
             e.stopPropagation();
-            this.props.galleryContainerRef.focus();
+            this.props.actions.focusGalleryContainer();
             return false;
           }
           break;

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -467,7 +467,7 @@ class SlideshowView extends GalleryComponent {
       e.preventDefault();
       this._next({ direction: getDirection(code), isKeyboardNavigation: true });
       return false;
-    } else if (code === 27 && this.props.galleryContainerRef) {
+    } else if (code === 27) {
       this.props.actions.focusGalleryContainer();
       return false;
     }

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -468,7 +468,7 @@ class SlideshowView extends GalleryComponent {
       this._next({ direction: getDirection(code), isKeyboardNavigation: true });
       return false;
     } else if (code === 27 && this.props.galleryContainerRef) {
-      this.props.galleryContainerRef.focus()
+      this.props.actions.focusGalleryContainer();
       return false;
     }
     return true

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1326,7 +1326,6 @@ class SlideshowView extends GalleryComponent {
       should = true;
     } else if (
       isInFocus &&
-      styleParams.pauseAutoSlideshowOnHover &&
       styleParams.isAccessible
     ) {
       should = true;

--- a/packages/gallery/tests/components/gallery/galleryView.spec.js
+++ b/packages/gallery/tests/components/gallery/galleryView.spec.js
@@ -82,7 +82,7 @@ describe('Gallery View', () => {
       const stub_findNeighborItem = sinon
         .stub(driver.get.props().galleryStructure, 'findNeighborItem')
         .returns(3);
-      const result = driver.get.instance().handleArrowKeys({
+      const result = driver.get.instance().handleKeys({
         keyCode: 38,
         charCode: null,
         preventDefault() {},
@@ -106,7 +106,7 @@ describe('Gallery View', () => {
       const stub_findNeighborItem = sinon
         .stub(driver.get.props().galleryStructure, 'findNeighborItem')
         .returns(16);
-      const result = driver.get.instance().handleArrowKeys({
+      const result = driver.get.instance().handleKeys({
         keyCode: 37,
         charCode: null,
         preventDefault() {},
@@ -130,7 +130,7 @@ describe('Gallery View', () => {
       const stub_findNeighborItem = sinon
         .stub(driver.get.props().galleryStructure, 'findNeighborItem')
         .returns(10);
-      const result = driver.get.instance().handleArrowKeys({
+      const result = driver.get.instance().handleKeys({
         keyCode: 40,
         charCode: null,
         preventDefault() {},
@@ -154,7 +154,7 @@ describe('Gallery View', () => {
       const stub_findNeighborItem = sinon
         .stub(driver.get.props().galleryStructure, 'findNeighborItem')
         .returns(3);
-      const result = driver.get.instance().handleArrowKeys({
+      const result = driver.get.instance().handleKeys({
         keyCode: null,
         charCode: 39,
         preventDefault() {},
@@ -177,7 +177,7 @@ describe('Gallery View', () => {
       const stub_findNeighborItem = sinon
         .stub(driver.get.props().galleryStructure, 'findNeighborItem')
         .returns(3);
-      const result = driver.get.instance().handleArrowKeys({
+      const result = driver.get.instance().handleKeys({
         keyCode: null,
         charCode: 2,
         preventDefault() {},


### PR DESCRIPTION
accessibility changes:

when visitors hit the Esc key (keyCode === 27), move the focus to the gallery container.
+ pauseOnFocus : remove unnecessary check from blockAutoSlideShow (refactor)
