### PR TITLE
heddle ARIA attributes in core

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -722,6 +722,8 @@ export class GalleryContainer extends React.Component {
       ? SlideshowView
       : GalleryView;
 
+    const getAriaAttributes = this.getAriaAttributes();
+    
     if (utils.isVerbose()) {
       console.count('PROGALLERY [COUNTS] - GalleryContainer (render)');
       console.log(
@@ -783,7 +785,7 @@ export class GalleryContainer extends React.Component {
           firstUserInteractionExecuted={this.state.firstUserInteractionExecuted}
           isGalleryInHover={this.state.isInHover}
           galleryContainerRef={this.galleryContainerRef}
-          getAriaAttributes={this.getAriaAttributes}
+          getAriaAttributes={getAriaAttributes}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -36,7 +36,6 @@ export class GalleryContainer extends React.Component {
     this.onGalleryScroll = this.onGalleryScroll.bind(this);
     this.setPlayingIdxState = this.setPlayingIdxState.bind(this);
     this.getVisibleItems = this.getVisibleItems.bind(this);
-    this.getAriaAttributes = this.getAriaAttributes.bind(this);
     this.findNeighborItem = this.findNeighborItem.bind(this);
     this.setCurrentSlideshowViewIdx =
       this.setCurrentSlideshowViewIdx.bind(this);
@@ -638,17 +637,6 @@ export class GalleryContainer extends React.Component {
     }
   }
 
-  getAriaAttributes() {
-    return {
-      role: this.props.proGalleryRole,
-      ['aria-label']: this.props.proGalleryAriaLabel,
-      ['aria-roledescription']:
-        this.props.proGalleryRole === 'application'
-          ? 'gallery application'
-          : 'region',
-    };
-  }
-
   getMoreItemsIfNeeded(scrollPos) {
     if (
       this.galleryStructure &&
@@ -721,9 +709,7 @@ export class GalleryContainer extends React.Component {
     const ViewComponent = this.props.styles.oneRow
       ? SlideshowView
       : GalleryView;
-
-    const getAriaAttributes = this.getAriaAttributes();
-    
+ 
     if (utils.isVerbose()) {
       console.count('PROGALLERY [COUNTS] - GalleryContainer (render)');
       console.log(
@@ -782,10 +768,11 @@ export class GalleryContainer extends React.Component {
           customNavArrowsRenderer={this.props.customNavArrowsRenderer}
           playingVideoIdx={this.state.playingVideoIdx}
           noFollowForSEO={this.props.noFollowForSEO}
+          proGalleryAriaLabel={this.props.proGalleryAriaLabel}
+          proGalleryRole={this.props.proGalleryRole}
           firstUserInteractionExecuted={this.state.firstUserInteractionExecuted}
           isGalleryInHover={this.state.isInHover}
           galleryContainerRef={this.galleryContainerRef}
-          getAriaAttributes={getAriaAttributes}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -36,6 +36,7 @@ export class GalleryContainer extends React.Component {
     this.onGalleryScroll = this.onGalleryScroll.bind(this);
     this.setPlayingIdxState = this.setPlayingIdxState.bind(this);
     this.getVisibleItems = this.getVisibleItems.bind(this);
+    this.getAriaAttributes = this.getAriaAttributes.bind(this);
     this.findNeighborItem = this.findNeighborItem.bind(this);
     this.setCurrentSlideshowViewIdx =
       this.setCurrentSlideshowViewIdx.bind(this);
@@ -637,6 +638,17 @@ export class GalleryContainer extends React.Component {
     }
   }
 
+  getAriaAttributes() {
+    return {
+      role: this.props.proGalleryRole,
+      ['aria-label']: this.props.proGalleryAriaLabel,
+      ['aria-roledescription']:
+        this.props.proGalleryRole === 'application'
+          ? 'gallery application'
+          : 'region',
+    };
+  }
+
   getMoreItemsIfNeeded(scrollPos) {
     if (
       this.galleryStructure &&
@@ -768,10 +780,10 @@ export class GalleryContainer extends React.Component {
           customNavArrowsRenderer={this.props.customNavArrowsRenderer}
           playingVideoIdx={this.state.playingVideoIdx}
           noFollowForSEO={this.props.noFollowForSEO}
-          proGalleryRegionLabel={this.props.proGalleryRegionLabel}
           firstUserInteractionExecuted={this.state.firstUserInteractionExecuted}
           isGalleryInHover={this.state.isInHover}
           galleryContainerRef={this.galleryContainerRef}
+          getAriaAttributes={this.getAriaAttributes}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -709,7 +709,7 @@ export class GalleryContainer extends React.Component {
     const ViewComponent = this.props.styles.oneRow
       ? SlideshowView
       : GalleryView;
- 
+
     if (utils.isVerbose()) {
       console.count('PROGALLERY [COUNTS] - GalleryContainer (render)');
       console.log(

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -768,7 +768,7 @@ export class GalleryContainer extends React.Component {
           customNavArrowsRenderer={this.props.customNavArrowsRenderer}
           playingVideoIdx={this.state.playingVideoIdx}
           noFollowForSEO={this.props.noFollowForSEO}
-          proGalleryAriaLabel={this.props.proGalleryAriaLabel}
+          proGalleryRegionLabel={this.props.proGalleryRegionLabel}
           proGalleryRole={this.props.proGalleryRole}
           firstUserInteractionExecuted={this.state.firstUserInteractionExecuted}
           isGalleryInHover={this.state.isInHover}

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -296,8 +296,7 @@ class GalleryView extends GalleryComponent {
       <div
         className={'pro-gallery-parent-container'}
         key={`pro-gallery-${this.id}`}
-        role="region"
-        aria-label={this.props.proGalleryRegionLabel}
+        {...this.props.getAriaAttributes()}
       >
         {screenLogs}
         {gallery}

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -296,7 +296,7 @@ class GalleryView extends GalleryComponent {
       <div
         className={'pro-gallery-parent-container'}
         key={`pro-gallery-${this.id}`}
-        {...this.props.getAriaAttributes()}
+        {...this.props.getAriaAttributes}
       >
         {screenLogs}
         {gallery}

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -296,7 +296,7 @@ class GalleryView extends GalleryComponent {
       <div
         className={'pro-gallery-parent-container'}
         key={`pro-gallery-${this.id}`}
-        {...this.props.getAriaAttributes}
+        {...utils.getAriaAttributes(this.props)}
       >
         {screenLogs}
         {gallery}

--- a/packages/gallery/src/components/gallery/proGallery/proGallery.js
+++ b/packages/gallery/src/components/gallery/proGallery/proGallery.js
@@ -44,9 +44,10 @@ export default class ProGallery extends GalleryComponent {
       settings: this.props.settings || {},
       offsetTop: this.props.offsetTop,
       itemsLoveData: this.props.itemsLoveData || {},
-      proGalleryRegionLabel:
+      proGalleryRole: this.props.proGalleryRole || 'region',
+      proGalleryAriaLabel:
         this.props.proGalleryRegionLabel ||
-        'Gallery. you can navigate the gallery with keyboard arrow keys.',
+        'You can navigate the gallery with keyboard arrow keys.',
     };
   }
 

--- a/packages/gallery/src/components/gallery/proGallery/proGallery.js
+++ b/packages/gallery/src/components/gallery/proGallery/proGallery.js
@@ -44,10 +44,7 @@ export default class ProGallery extends GalleryComponent {
       settings: this.props.settings || {},
       offsetTop: this.props.offsetTop,
       itemsLoveData: this.props.itemsLoveData || {},
-      proGalleryRole: this.props.proGalleryRole || 'region',
-      proGalleryAriaLabel:
-        this.props.proGalleryRegionLabel ||
-        'You can navigate the gallery with keyboard arrow keys.',
+      proGalleryRegionLabel: this.props.proGalleryRegionLabel,
     };
   }
 

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1512,7 +1512,7 @@ class SlideshowView extends GalleryComponent {
         className={this.getClassNames()}
         style={this.getStyles()}
         onKeyDown={this.handleSlideshowKeyPress}
-        {...this.props.getAriaAttributes}
+        {...utils.getAriaAttributes(this.props)}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
       >

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1512,7 +1512,7 @@ class SlideshowView extends GalleryComponent {
         className={this.getClassNames()}
         style={this.getStyles()}
         onKeyDown={this.handleSlideshowKeyPress}
-        {...this.props.getAriaAttributes()}
+        {...this.props.getAriaAttributes}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
       >

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1512,8 +1512,7 @@ class SlideshowView extends GalleryComponent {
         className={this.getClassNames()}
         style={this.getStyles()}
         onKeyDown={this.handleSlideshowKeyPress}
-        role="region"
-        aria-label={this.props.proGalleryRegionLabel}
+        {...this.props.getAriaAttributes()}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
       >

--- a/packages/lib/src/common/utils/index.js
+++ b/packages/lib/src/common/utils/index.js
@@ -653,12 +653,11 @@ class Utils {
       styles.cubeRatio === '100%/100%';
   }
 
-  getAriaAttributes(props) {
-    const { proGalleryRole, proGalleryRegionLabel } = props;
+  getAriaAttributes({ proGalleryRole, proGalleryRegionLabel }) {
     return {
       role: proGalleryRole,
       ['aria-label']: proGalleryRegionLabel ||
-      'You can navigate the gallery with keyboard arrow keys.',
+        'You can navigate the gallery with keyboard arrow keys.',
       ['aria-roledescription']:
         proGalleryRole === 'application' ? 'gallery application' : 'region',
     };

--- a/packages/lib/src/common/utils/index.js
+++ b/packages/lib/src/common/utils/index.js
@@ -654,17 +654,18 @@ class Utils {
   }
 
   getAriaAttributes(props) {
-    const { proGalleryRole, proGalleryAriaLabel } = props;
+    console.log(props);
+    const { proGalleryRole, proGalleryRegionLabel } = props;
+    const proGalleyRegion =
+      proGalleryRegionLabel ||
+      'You can navigate the gallery with keyboard arrow keys.';
     return {
       role: proGalleryRole,
-      ['aria-label']: proGalleryAriaLabel,
+      ['aria-label']: proGalleyRegion,
       ['aria-roledescription']:
-        proGalleryRole === 'application'
-          ? 'gallery application'
-          : 'region',
+        proGalleryRole === 'application' ? 'gallery application' : 'region',
     };
   }
-  
 }
 
 export default new Utils();

--- a/packages/lib/src/common/utils/index.js
+++ b/packages/lib/src/common/utils/index.js
@@ -652,6 +652,19 @@ class Utils {
       styles.cubeImages &&
       styles.cubeRatio === '100%/100%';
   }
+
+  getAriaAttributes(props) {
+    const { proGalleryRole, proGalleryAriaLabel } = props;
+    return {
+      role: proGalleryRole,
+      ['aria-label']: proGalleryAriaLabel,
+      ['aria-roledescription']:
+        proGalleryRole === 'application'
+          ? 'gallery application'
+          : 'region',
+    };
+  }
+  
 }
 
 export default new Utils();

--- a/packages/lib/src/common/utils/index.js
+++ b/packages/lib/src/common/utils/index.js
@@ -654,14 +654,11 @@ class Utils {
   }
 
   getAriaAttributes(props) {
-    console.log(props);
     const { proGalleryRole, proGalleryRegionLabel } = props;
-    const proGalleyRegion =
-      proGalleryRegionLabel ||
-      'You can navigate the gallery with keyboard arrow keys.';
     return {
       role: proGalleryRole,
-      ['aria-label']: proGalleyRegion,
+      ['aria-label']: proGalleryRegionLabel ||
+      'You can navigate the gallery with keyboard arrow keys.',
       ['aria-roledescription']:
         proGalleryRole === 'application' ? 'gallery application' : 'region',
     };


### PR DESCRIPTION
accessibility changes.

When the gallery is initialized in "application" mode:

* set role="application" (instead of role="region"),
* set aria-roledescription="gallery application"

When the gallery NOT is initialized in "application" mode:

* set the aria-label attribute value to "feed" (verticals can still override it, e.g. "Blog feed, Select a post to read").
* set the container role to "region"

link to the "photography-pro-gallery" changes: https://github.com/wix-private/photography-pro-gallery/pull/22/files
