### PR TITLE
added indication for loaded image

### DIFF
--- a/packages/gallery/src/components/item/imageItem.js
+++ b/packages/gallery/src/components/item/imageItem.js
@@ -40,6 +40,7 @@ export default class ImageItem extends GalleryComponent {
 
   getImageContainerClassNames() {
     const { styleParams } = this.props;
+    const { isHighResImageLoaded } = this.state;
 
     const imageContainerClassNames = [
       'gallery-item-content',
@@ -51,7 +52,7 @@ export default class ImageItem extends GalleryComponent {
         ? 'grid-fit'
         : '',
       styleParams.imageLoadingMode === GALLERY_CONSTS.loadingMode.COLOR
-        ? 'load-with-color'
+        ? `load-with-color ${isHighResImageLoaded ? 'image-loaded' : ''}`
         : '',
     ].join(' ');
 


### PR DESCRIPTION
**What** - adding a class to the image container to indicate when images are loaded
**Why** - right now the wrapper (cpgcw) is applying the placeholder loading color and we want to remove it once the images are loaded, and we can do that by filtering the classes in the wrapper CSS