### PR TITLE
add formFactor to main flow

### DIFF
--- a/packages/gallery/src/components/gallery/index.js
+++ b/packages/gallery/src/components/gallery/index.js
@@ -9,6 +9,7 @@ export default class BaseGallery extends React.Component {
     this.isUsingCustomInfoElements = this.isUsingCustomInfoElements.bind(this);
     this.blueprintsManager = new BlueprintsManager({ id: 'layoutingGallery' });
     this.blueprintsManager.init({
+      formFactor: props.formFactor,
       api: {
         isUsingCustomInfoElements: this.isUsingCustomInfoElements,
         fetchMoreItems: (from) => {


### PR DESCRIPTION
The formFactor (desktop/mobile) is critical for the blueprint.
Currently the ProGallery flow isn't provided with the formFactor (a bug in the code).

This will provide the formFactor to the blueprintManager as it should be in its initialization.