### PR TITLE
[gallery] remove video poster and background when needed

### DIFF
--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -71,6 +71,6 @@ export function changeActiveElementIfNeeded({
 export function shouldCreateVideoPlaceholder(styles) {
   return (
     !utils.isSingleItemHorizontalDisplay(styles) ||
-    !styles.videoPlay === GALLERY_CONSTS.videoPlay.AUTO
+    styles.videoPlay !== GALLERY_CONSTS.videoPlay.AUTO
   );
 }

--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -1,4 +1,10 @@
-import { window, utils, isSiteMode, isSEOMode } from 'pro-gallery-lib';
+import {
+  window,
+  utils,
+  isSiteMode,
+  isSEOMode,
+  GALLERY_CONSTS,
+} from 'pro-gallery-lib';
 
 function shouldChangeActiveElement() {
   return (isSiteMode() || isSEOMode()) && !utils.isMobile() && window.document;
@@ -60,4 +66,11 @@ export function changeActiveElementIfNeeded({
   } catch (e) {
     console.error('Could not set focus to active element', e);
   }
+}
+
+export function shouldCreateVideoPlaceholder(styles) {
+  return (
+    !utils.isSingleItemHorizontalDisplay(styles) ||
+    !styles.videoPlay === GALLERY_CONSTS.videoPlay.AUTO
+  );
 }

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -315,7 +315,10 @@ class VideoItem extends GalleryComponent {
 
     return (
       <div key={'video-and-hover-container' + this.props.idx}>
-        {[video, videoPlaceholder, hover]}
+        {video}
+        {shouldCreateVideoPlaceholder(this.props.styleParams) &&
+          videoPlaceholder}
+        {hover}
       </div>
     );
   }

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GALLERY_CONSTS, window, utils } from 'pro-gallery-lib';
 import { GalleryComponent } from '../../galleryComponent';
+import { shouldCreateVideoPlaceholder } from '../itemHelper';
 
 class VideoItem extends GalleryComponent {
   constructor(props) {
@@ -231,10 +232,12 @@ class VideoItem extends GalleryComponent {
               disablepictureinpicture: 'true',
               muted: !this.props.styleParams.videoSound,
               preload: 'metadata',
-              poster: this.props.createUrl(
-                GALLERY_CONSTS.urlSizes.SCALED,
-                GALLERY_CONSTS.urlTypes.HIGH_RES
-              ),
+              poster: shouldCreateVideoPlaceholder(this.props.styleParams)
+                ? this.props.createUrl(
+                    GALLERY_CONSTS.urlSizes.SCALED,
+                    GALLERY_CONSTS.urlTypes.HIGH_RES
+                  )
+                : '',
               style: videoDimensionsCss,
               type: 'video/mp4',
             },
@@ -288,7 +291,9 @@ class VideoItem extends GalleryComponent {
         data-hook="video_container-video-player-element"
         key={'video_container-' + this.props.id}
         style={
-          utils.deviceHasMemoryIssues() || this.state.ready
+          utils.deviceHasMemoryIssues() ||
+          this.state.ready ||
+          !shouldCreateVideoPlaceholder(this.props.styleParams)
             ? { backgroundColor: 'black' }
             : {
                 backgroundImage: `url(${this.props.createUrl(

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -177,6 +177,23 @@ class VideoItem extends GalleryComponent {
           GALLERY_CONSTS.urlSizes.RESIZED,
           GALLERY_CONSTS.urlTypes.VIDEO
         );
+
+    const attributes = {
+      controlsList: 'nodownload',
+      disablepictureinpicture: 'true',
+      muted: !this.props.styleParams.videoSound,
+      preload: 'metadata',
+      style: videoDimensionsCss,
+      type: 'video/mp4',
+    };
+
+    if (shouldCreateVideoPlaceholder(this.props.styleParams)) {
+      attributes.poster = this.props.createUrl(
+        GALLERY_CONSTS.urlSizes.SCALED,
+        GALLERY_CONSTS.urlTypes.HIGH_RES
+      );
+    }
+
     return (
       <PlayerElement
         className={'gallery-item-visible video gallery-item'}
@@ -227,20 +244,7 @@ class VideoItem extends GalleryComponent {
         controls={this.props.styleParams.showVideoControls}
         config={{
           file: {
-            attributes: {
-              controlsList: 'nodownload',
-              disablepictureinpicture: 'true',
-              muted: !this.props.styleParams.videoSound,
-              preload: 'metadata',
-              poster: shouldCreateVideoPlaceholder(this.props.styleParams)
-                ? this.props.createUrl(
-                    GALLERY_CONSTS.urlSizes.SCALED,
-                    GALLERY_CONSTS.urlTypes.HIGH_RES
-                  )
-                : '',
-              style: videoDimensionsCss,
-              type: 'video/mp4',
-            },
+            attributes,
             forceHLS: this.shouldUseHlsPlayer(),
             forceVideo: this.shouldForceVideoForHLS(),
           },

--- a/packages/gallery/src/components/item/videos/videoItemWrapper.js
+++ b/packages/gallery/src/components/item/videos/videoItemWrapper.js
@@ -30,8 +30,8 @@ class VideoItemWrapper extends ImageItem {
   constructor(props) {
     super(props);
     this.mightPlayVideo = this.mightPlayVideo.bind(this);
-    this.createVideoPlaceholderIfNeeded =
-      this.createVideoPlaceholderIfNeeded.bind(this);
+    this.createVideoPlaceholder=
+      this.createVideoPlaceholder.bind(this);
     this.state = { VideoItemLoaded: false };
   }
 
@@ -52,8 +52,7 @@ class VideoItemWrapper extends ImageItem {
     return false;
   }
 
-  createVideoPlaceholderIfNeeded(showVideoPlayButton) {
-    const {styleParams} = this.props;
+  createVideoPlaceholder(showVideoPlayButton) {
     const props = utils.pick(this.props, [
       'alt',
       'title',
@@ -66,7 +65,7 @@ class VideoItemWrapper extends ImageItem {
       'actions',
     ]);
 
-    return !shouldCreateVideoPlaceholder(styleParams) ? null : (
+    return (
       <VideoItemPlaceholder
         {...props}
         key="videoPlaceholder"
@@ -100,13 +99,13 @@ class VideoItemWrapper extends ImageItem {
     const hover = this.props.hover;
     const showVideoPlayButton =
       !this.props.hidePlay && this.props.styleParams.showVideoPlayButton;
-    const videoPlaceholder = this.createVideoPlaceholderIfNeeded(showVideoPlayButton);
+    const videoPlaceholder = this.createVideoPlaceholder(showVideoPlayButton);
 
     const VideoItem = this.VideoItem;
     if (!this.mightPlayVideo() || !VideoItem) {
       return (
         <div>
-          {videoPlaceholder}
+          {!shouldCreateVideoPlaceholder(this.props.styleParams) && videoPlaceholder}
           {hover}
         </div>
       );

--- a/packages/gallery/src/components/item/videos/videoItemWrapper.js
+++ b/packages/gallery/src/components/item/videos/videoItemWrapper.js
@@ -105,7 +105,7 @@ class VideoItemWrapper extends ImageItem {
     if (!this.mightPlayVideo() || !VideoItem) {
       return (
         <div>
-          {!shouldCreateVideoPlaceholder(this.props.styleParams) && videoPlaceholder}
+          {shouldCreateVideoPlaceholder(this.props.styleParams) && videoPlaceholder}
           {hover}
         </div>
       );

--- a/packages/gallery/src/components/item/videos/videoItemWrapper.js
+++ b/packages/gallery/src/components/item/videos/videoItemWrapper.js
@@ -1,6 +1,7 @@
 /* eslint-disable prettier/prettier */
 import React from 'react';
-import { utils, isEditMode, GALLERY_CONSTS } from 'pro-gallery-lib';
+import { utils, isEditMode } from 'pro-gallery-lib';
+import { shouldCreateVideoPlaceholder } from '../itemHelper';
 import ImageItem from '../imageItem';
 import PlayBackground from '../../svgs/components/play_background';
 import PlayTriangle from '../../svgs/components/play_triangle';
@@ -64,11 +65,8 @@ class VideoItemWrapper extends ImageItem {
       'settings',
       'actions',
     ]);
-    const shouldCreatePlaceHolder =
-      utils.isSingleItemHorizontalDisplay(styleParams) && 
-      styleParams.videoPlay === GALLERY_CONSTS.videoPlay.AUTO;
 
-    return shouldCreatePlaceHolder ? null : (
+    return !shouldCreateVideoPlaceholder(styleParams) ? null : (
       <VideoItemPlaceholder
         {...props}
         key="videoPlaceholder"


### PR DESCRIPTION
**what** -  removing the posters/background for videos in certain cases (single horizontal item view + auto play) and a small refactor.
**why** - we don't want to display the placeholder/posters in videos in the case mentioned (placeholder was already removed in earlier PR, had to do the same for the video poster and background)

