### PR TITLE
V4 type: container

### DIFF
--- a/packages/gallery/src/common/interfaces/Container.ts
+++ b/packages/gallery/src/common/interfaces/Container.ts
@@ -1,4 +1,4 @@
-export interface Dimensions {
+export interface Container {
   width: number;
   height?: number;
   scrollBase?: number;

--- a/packages/gallery/src/components/gallery/galleryTypes.ts
+++ b/packages/gallery/src/components/gallery/galleryTypes.ts
@@ -1,9 +1,11 @@
 import { PhotoItem, VideoItem, TextItem } from '../../common/interfaces/Item';
+import { Container } from '../../common/interfaces/Container';
 
 type ViewMode = 'SITE' | 'EDIT' | 'PREVIEW' | 'SEO';
 type FormFactor = 'desktop' | 'mobile' | 'tablet';
 
 export interface GalleryProps {
+  container: Container;
   domId?: string;
   totalItemsCount: number;
   items: (PhotoItem | VideoItem | TextItem)[];

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -29,7 +29,7 @@ To use the blueprints Manager to the full extent you need to provide it with an 
 | `fetchMoreItems` | Will be called when the BM requires more items (under the totalItemsCount) | currentItemLength: number | --
 | `fetchItems`  | Will be called by the BM to get the current items| -- | items
 | `fetchStyles`  | Will be called by the BM to get the current styles | -- | styles
-| `fetchDimensions`  | Will be called by the BM to get the current dimensions | -- | dimensions
+| `fetchContainer`  | Will be called by the BM to get the current container | -- | container
 | `getTotalItemsCount`  | Will be called by the BM to get the totalItemsCount | -- | totalItemsCount: number
 | `onBlueprintReady`  | Will be called by the BM when a requested blueprint is ready | {blueprint: object, blueprintChanged: boolean} | --
 | `isUsingCustomInfoElements`  | Will be called by the BM to know if Custom Info Elements are used | -- | boolean
@@ -53,8 +53,8 @@ const blueprintsManager = new BlueprintsManager({
         fetchStyles() {
             //return the current styles object;
         }
-        fetchDimensions() {
-            //return the current dimensions object;
+        fetchContainer() {
+            //return the current container object;
         }
         getTotalItemsCount() {
             //return the current totalItemsCount;
@@ -72,7 +72,7 @@ blueprintsManager.init({
     formFactor: GALLERY_CONSTS.formFactor.DESKTOP,
     // totalItemsCont, This is optional and can be passed in the params in createBlueprint(params) or via the api;
 });
-const triggerBlueprintCreation = () => { //call this whenever something changes (styles/ items/ dimensions...anything). If this was called and nothing relevant changed the BM will call the onBlueprintReady api with a false blueprintChanged flag.
+const triggerBlueprintCreation = () => { //call this whenever something changes (styles/ items/ container...anything). If this was called and nothing relevant changed the BM will call the onBlueprintReady api with a false blueprintChanged flag.
     blueprintsManager.createBlueprint({}); //since the api is used params can be empty, the BM will use the provided api to fetch all the needed params to create a blueprint.
 }
 

--- a/packages/lib/src/core/blueprints/Blueprints.js
+++ b/packages/lib/src/core/blueprints/Blueprints.js
@@ -1,5 +1,4 @@
 /* eslint-disable prettier/prettier */
-//dummy
 import { Layouter } from 'pro-layouts';
 import defaultStyles from '../../common/defaultStyles';
 import { addPresetStyles } from '../presets/presets';
@@ -22,12 +21,12 @@ class Blueprints {
     let changedParams = {};
     try {
       const {
-        dimensions: newDimensionsParams,
+        container: newContainerParams,
         items: newItemsParams,
         styles: newStylesParams,
       } = params;
       const {
-        dimensions: oldDimensionsParams,
+        container: oldContainerParams,
         items: oldItemsParams,
         styles: oldStylesParams,
       } = lastParams;
@@ -43,8 +42,8 @@ class Blueprints {
         );
       const { formattedContainer, changed: containerChanged } =
         this.formatContainerIfNeeded(
-          newDimensionsParams,
-          oldDimensionsParams,
+          newContainerParams,
+          oldContainerParams,
           oldStylesParams,
           formattedStyles || existingBlueprint.styles,
           stylesChanged
@@ -259,72 +258,72 @@ class Blueprints {
   }
 
   formatContainerIfNeeded(
-    dimensions,
-    lastDimensions,
+    container,
+    lastContainer,
     lastStyles,
     formattedStyles,
     stylesChanged
   ) {
     const reason = {
-      dimensions: '',
+      container: '',
     };
-    const dimensionsHaveChanged = ({
-      newDimensionsParams,
-      oldDimensionsParams,
+    const containerHasChanged = ({
+      newContainerParams,
+      oldContainerParams,
       oldStylesParams,
     }) => {
-      if (!oldStylesParams || !oldDimensionsParams) {
-        reason.dimensions = 'no old dimensions or styles. ';
-        return true; // no old dimensions or styles (style may change dimensions)
+      if (!oldStylesParams || !oldContainerParams) {
+        reason.container = 'no old container or styles. ';
+        return true; // no old container or styles (style may change container)
       }
-      if (!newDimensionsParams) {
-        reason.dimensions = 'no new dimensions.';
+      if (!newContainerParams) {
+        reason.container = 'no new container.';
         return false; // no new continainer
       }
-      const dimensionsHaveChanged = {
+      const containerHasChanged = {
         height:
           formattedStyles.scrollDirection ===
             GALLERY_CONSTS.scrollDirection.VERTICAL &&
           formattedStyles.enableInfiniteScroll // height doesnt matter if the new gallery is going to be vertical
             ? false
-            : !!newDimensionsParams.height &&
-              newDimensionsParams.height !== oldDimensionsParams.height,
+            : !!newContainerParams.height &&
+              newContainerParams.height !== oldContainerParams.height,
         width:
-          !oldDimensionsParams ||
-          (!!newDimensionsParams.width &&
-            newDimensionsParams.width !== oldDimensionsParams.width),
+          !oldContainerParams ||
+          (!!newContainerParams.width &&
+            newContainerParams.width !== oldContainerParams.width),
         scrollBase:
-          !!newDimensionsParams.scrollBase &&
-          newDimensionsParams.scrollBase !== oldDimensionsParams.scrollBase,
+          !!newContainerParams.scrollBase &&
+          newContainerParams.scrollBase !== oldContainerParams.scrollBase,
       };
-      return Object.keys(dimensionsHaveChanged).reduce((is, key) => {
-        if (dimensionsHaveChanged[key]) {
-          reason.dimensions += `dimensions.${key} has changed. `;
+      return Object.keys(containerHasChanged).reduce((is, key) => {
+        if (containerHasChanged[key]) {
+          reason.container += `container.${key} has changed. `;
         }
-        return is || dimensionsHaveChanged[key];
+        return is || containerHasChanged[key];
       }, false);
     };
 
-    const oldDimensionsParams = lastDimensions;
+    const oldContainerParams = lastContainer;
     let changed = false;
     const oldStylesParams = lastStyles;
     let formattedContainer;
     if (
       stylesChanged || // If styles changed they could affect the container and a new container must be created (slideshow,thumbs,shadow,borders...etc)
-      dimensionsHaveChanged({
-        newDimensionsParams: dimensions,
-        oldDimensionsParams,
+      containerHasChanged({
+        newContainerParams: container,
+        oldContainerParams,
         oldStylesParams,
       })
     ) {
       dimensionsHelper.updateParams({
         styles: formattedStyles,
-        container: dimensions,
+        container: container,
       });
       changed = true;
       formattedContainer = Object.assign(
         {},
-        dimensions,
+        container,
         dimensionsHelper.getGalleryDimensions()
       );
     }

--- a/packages/lib/src/core/blueprints/Blueprints.js
+++ b/packages/lib/src/core/blueprints/Blueprints.js
@@ -318,7 +318,7 @@ class Blueprints {
     ) {
       dimensionsHelper.updateParams({
         styles: formattedStyles,
-        container: container,
+        container,
       });
       changed = true;
       formattedContainer = Object.assign(

--- a/packages/lib/src/core/blueprints/BlueprintsManager.js
+++ b/packages/lib/src/core/blueprints/BlueprintsManager.js
@@ -150,42 +150,40 @@ export default class BlueprintsManager {
 
   // ------------------ Get all the needed raw data ---------------------------- //
   async completeParams(params) {
-    let { dimensions, items, styles, domId } =
+    let { container, items, styles, domId } =
       this.alignParamNamingOptions(params);
-    dimensions = await this.fetchDimensionsIfNeeded(dimensions);
+    container = await this.fetchContainerIfNeeded(container);
     items = await this.fetchItemsIfNeeded(items);
     styles = await this.fetchStylesIfNeeded(styles); // can be async... TODO
-    return { dimensions, items, styles, domId };
+    return { container, items, styles, domId };
   }
 
   alignParamNamingOptions(params) {
-    let { dimensions, container, items, styles, styleParams, options, domId } =
+    let { container, items, styles, styleParams, options, domId } =
       params || {};
 
     styles = { ...options, ...styles, ...styleParams };
-    dimensions = { ...dimensions, ...container };
 
-    return { dimensions, items, styles, domId };
+    return { container, items, styles, domId };
   }
 
-  async fetchDimensionsIfNeeded(dimensions) {
-    const shouldFetchDimensions = (_dimensions) => {
+  async fetchContainerIfNeeded(container) {
+    const shouldFetchContainer = (_container) => {
       let should = true;
-      if (_dimensions && Object.keys(_dimensions).length > 0) {
+      if (_container && Object.keys(_container).length > 0) {
         should = false;
       }
-
       return should;
     };
 
-    if (shouldFetchDimensions(dimensions)) {
+    if (shouldFetchContainer(container)) {
       // dimensions = {yonatanFakeDimensions: true, width: "", height: ""} // TODO - is there something here???
-      dimensions =
-        (this.api.fetchDimensions && (await this.api.fetchDimensions())) ||
-        this.currentState.dimensions;
+      container =
+        (this.api.fetchContainer && (await this.api.fetchContainer())) ||
+        this.currentState.container;
     }
 
-    return dimensions;
+    return container;
   }
 
   async fetchItemsIfNeeded(items) {
@@ -233,7 +231,7 @@ export default class BlueprintsManager {
   }
 
   updateLastParamsIfNeeded(
-    { items, dimensions, styles },
+    { items, container, styles },
     changedParams,
     blueprintCreated
   ) {
@@ -241,9 +239,9 @@ export default class BlueprintsManager {
       this.currentState.items = changedParams.itemsChanged
         ? items
         : this.currentState.items;
-      this.currentState.dimensions = changedParams.containerChanged
-        ? { ...dimensions }
-        : this.currentState.dimensions;
+      this.currentState.container = changedParams.containerChanged
+        ? { ...container }
+        : this.currentState.container;
       this.currentState.styles = changedParams.stylesChanged
         ? { ...styles }
         : this.currentState.styles;

--- a/packages/playground/src/components/App/App.js
+++ b/packages/playground/src/components/App/App.js
@@ -33,7 +33,7 @@ let sideShownOnce = false;
 let totalItems = 0;
 
 export function App() {
-  const {getBlueprintFromServer, setDimensions, styleParams, setItems, items, gallerySettings, setBlueprint, blueprint, dimensions, setShowSide} = useGalleryContext(blueprintsManager);
+  const {getBlueprintFromServer, setContainer, styleParams, setItems, items, gallerySettings, setBlueprint, blueprint, container, setShowSide} = useGalleryContext(blueprintsManager);
   const {showSide} = gallerySettings;
   sideShownOnce = sideShownOnce || showSide;
 
@@ -73,7 +73,7 @@ export function App() {
         break;
       case GALLERY_EVENTS.GALLERY_CHANGE: //TODO split to an event named "PARTIALY_GROW_GALLERY_PRETTY_PLEASE"
         if(eventData.updatedHeight){
-          setDimensions({height: eventData.updatedHeight});
+          setContainer({height: eventData.updatedHeight});
         }
         break;
       case GALLERY_EVENTS.NEED_MORE_ITEMS:
@@ -151,7 +151,7 @@ export function App() {
       return blueprint;
     } else if (gallerySettings.shouldUseBlueprintsFromServer) {
       const params = {
-        dimensions: getContainer(),
+        container: getContainer(),
         styleParams: getStyles(),
         items: getItems()
       }
@@ -159,7 +159,7 @@ export function App() {
     } else {
       const playgroundBlueprintsApi = new BlueprintsApi({addItems, getItems, getContainer, getStyles, onBlueprintReady: setBlueprint, getTotalItemsCount});
       blueprintsManager.init({api: playgroundBlueprintsApi})
-      blueprintsManager.createBlueprint({items: getItems(), styles: getStyles(), dimensions: getContainer(), totalItemsCount: getTotalItemsCount()}, true);
+      blueprintsManager.createBlueprint({items: getItems(), styles: getStyles(), container: getContainer(), totalItemsCount: getTotalItemsCount()}, true);
     }
   }
 
@@ -205,7 +205,7 @@ export function App() {
   const slideshowInfoElement = (pgItemProps) => {
     return renderInfoElement('SLIDESHOW', pgItemProps);
   };
-  
+
   const getExternalInfoRenderers = () => {
     return {
       customHoverRenderer: hoverInfoElement,
@@ -215,7 +215,7 @@ export function App() {
   }
 
   const getContainer = () => {
-    return {scrollBase: 0, ...dimensions, ...(gallerySettings.responsivePreview && resizedDims)};
+    return {scrollBase: 0, ...container, ...(gallerySettings.responsivePreview && resizedDims)};
   }
 
   const getStyles = () => {
@@ -231,11 +231,11 @@ export function App() {
   }
 
   useEffect(() => {
-    window.addEventListener('resize', setDimensions);
+    window.addEventListener('resize', setContainer);
     return () => {
-      window.removeEventListener('resize', setDimensions);
+      window.removeEventListener('resize', setContainer);
     };
-  }, [setDimensions]);
+  }, [setContainer]);
 
   if (!isTestingEnv) { // isTestingEnvironment is not a valid style param and would be removed from the url if we use setStyleParamsInUrl. this removed this protection for testing environment as well
     setStyleParamsInUrl(styleParams);
@@ -269,7 +269,7 @@ export function App() {
   };
 
   window.playgroundItems = getItems();
-  
+
   return (
     <main id="sidebar_main" className={s.main}>
       {/* <Loader/> */}
@@ -301,7 +301,7 @@ export function App() {
           useLayoutFixer: gallerySettings.useLayoutFixer,
           ...getExternalInfoRenderers(),
           ...blueprintProps
-        }, resizedDims, dims => {setDimensions(dims); setResizedDims(dims)}, gallerySettings)}
+        }, resizedDims, dims => {setContainer(dims); setResizedDims(dims)}, gallerySettings)}
       </section>
     </main>
   );

--- a/packages/playground/src/components/App/PlaygroundBlueprintsApi.js
+++ b/packages/playground/src/components/App/PlaygroundBlueprintsApi.js
@@ -32,7 +32,7 @@ export default class PlaygroundsBlueprintsApi {
     return this.getStyles();
   }
 
-  fetchDimensions() {
+  fetchContainer() {
     return this.getContainer();
   }
 

--- a/packages/playground/src/hooks/useGalleryContext.js
+++ b/packages/playground/src/hooks/useGalleryContext.js
@@ -17,21 +17,21 @@ export function useGalleryContext(
     setGallerySettings({ showSide: newShowSide });
     //    const widthChange = SIDEBAR_WIDTH * (newShowSide ? -1 : 1)
 
-    //  setDimensions({width: calcGalleryDimensions().width + widthChange});
-    setDimensions();
+    //  setDimensions({width: calcGalleryContainer().width + widthChange});
+    setContainer();
   };
 
   const getBlueprintFromServer = async (params) => {
-    let { items, styleParams, dimensions } = params;
+    let { items, styleParams, container } = params;
 
-    dimensions = dimensions || context.dimensions || calcGalleryDimensions();
+    container = container || context.container || calcGalleryContainer();
     const styles = styleParams || context.styleParams || getInitialStyleParams();
     const url = `https://www.wix.com/_serverless/pro-gallery-blueprints-server/createBlueprint`;
 
-    if (!items || !dimensions || !styles) {
+    if (!items || !container || !styles) {
       return;
     }
-    
+
     const response = await fetch(url, {
       method: 'POST',
       credentials: 'omit', // include, *same-origin, omit
@@ -41,7 +41,7 @@ export function useGalleryContext(
       body: JSON.stringify({
         items,
         styles,
-        dimensions
+        container
       }) // body data type must match "Content-Type" header
     });
     const data = await response.json();
@@ -59,19 +59,19 @@ export function useGalleryContext(
     }
   };
 
-  const setDimensions = (config = {}) => {
+  const setContainer = (config = {}) => {
     const { width, height } = config;
     const newContext = {
-      dimensions: {
-        ...calcGalleryDimensions(),
+      container: {
+        ...calcGalleryContainer(),
         ...(width && { width }),
         ...(height && { height }),
       },
     };
 
     if (
-      JSON.stringify(newContext.dimensions) !==
-      JSON.stringify({ ...context.dimensions })
+      JSON.stringify(newContext.container) !==
+      JSON.stringify({ ...context.container })
     ) {
       if (getGallerySettings().useBlueprints) {
         requestNewBlueprint(newContext);
@@ -152,12 +152,12 @@ export function useGalleryContext(
     }
   };
 
-  const calcGalleryDimensions = () => {
-    let dimensions = {};
+  const calcGalleryContainer = () => {
+    let container = {};
     const showSide = !!getGallerySettings().showSide && !utils.isMobile();
     // eslint-disable-next-line no-extra-boolean-cast
     if (!!getGallerySettings().isUnknownDimensions) {
-      dimensions = !utils.isMobile()
+      container = !utils.isMobile()
         ? {
             width: 500,
             height: 500,
@@ -167,13 +167,13 @@ export function useGalleryContext(
             height: 500,
           };
     } else {
-      dimensions.width = !showSide
+      container.width = !showSide
         ? window.innerWidth
         : window.innerWidth - SIDEBAR_WIDTH;
-      dimensions.height = window.innerHeight;
+      container.height = window.innerHeight;
     }
 
-    return dimensions;
+    return container;
   };
 
   const res = {
@@ -193,8 +193,8 @@ export function useGalleryContext(
     setGalleryReady,
     gallerySettings: getGallerySettings(),
     setGallerySettings,
-    dimensions: context.dimensions || calcGalleryDimensions(),
-    setDimensions,
+    container: context.container || calcGalleryContainer(),
+    setContainer,
     getBlueprintFromServer,
   };
 


### PR DESCRIPTION
We decided that the only prop for container/dimensions will be "container" and not "dimensions", as we had a lot of issues in our private (Wix) code with blueprint returning "dimensions", as this prop was already in use.
To minimize the refactor at the moment, we decided to go with "container".