### PR TITLE
videoItem: add playsinline to ReactPlayer props

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -259,7 +259,7 @@ class SlideshowView extends GalleryComponent {
       const _scrollDuration =
         scrollDuration || this.props.styleParams.scrollDuration || 400;
       const itemToScroll = ignoreScrollPosition ? 0 : nextItem;
-      
+
         !isScrollingPastEdge &&
        await scrollToItem(
           itemToScroll,
@@ -268,7 +268,7 @@ class SlideshowView extends GalleryComponent {
           _scrollDuration,
           scrollMarginCorrection
         );
-      
+
         if (this.props.styleParams.groupSize === 1) {
           const skipToSlide = this.skipFromSlide - this.props.totalItemsCount;
 
@@ -1014,6 +1014,7 @@ class SlideshowView extends GalleryComponent {
       isPrerenderMode: this.props.isPrerenderMode,
       totalWidth: this.props.galleryStructure.width,
       firstUserInteractionExecuted: this.props.firstUserInteractionExecuted,
+      enableExperimentalFeatures: this.props.enableExperimentalFeatures,
       actions: {
         eventsListener: this.props.actions.eventsListener,
       },

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -182,9 +182,11 @@ class VideoItem extends GalleryComponent {
       );
     }
 
+    const playsinline = !!this.props.enableExperimentalFeatures;
+
     return (
       <PlayerElement
-        playsinline
+        playsinline={playsinline}
         className={'gallery-item-visible video gallery-item'}
         id={`video-${this.props.id}`}
         width="100%"

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -72,6 +72,7 @@ class VideoItem extends GalleryComponent {
         this.props.videoUrl.includes('.m3u8'))
     );
   }
+
   shouldUseHlsPlayer() {
     return this.isHLSVideo() && !utils.isiOS();
   }
@@ -178,6 +179,7 @@ class VideoItem extends GalleryComponent {
 
     return (
       <PlayerElement
+        playsinline
         className={'gallery-item-visible video gallery-item'}
         id={`video-${this.props.id}`}
         width="100%"


### PR DESCRIPTION
When we were trying to play manually the video (when we have all the needed fields and data), [here](https://github.com/wix/pro-gallery/blob/master/packages/gallery/src/components/item/videos/videoItem.js#L125), in IOS we were getting the following error:
`Unhandled Promise Rejection: NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`

The issue is that in IOS, when not passing `playsinline` prop to the ReactPlayer, the ReactPlayer will open the video in fullscreen. In IOS, we cannot control manually (like calling a `play` function) the video in fullscreen from the code of the gallery.
The solution is to add `playsinline` to the ReactPlayer props.

This also making IOS playing videos in ProGallery look the same as in Androind.

This solution can be found here:
- https://stackoverflow.com/questions/59177977/video-is-not-auto-playing-on-ios-by-using-react-player-npm
- https://webkit.org/blog/6784/new-video-policies-for-ios/ (look for `playsinline`).