### PR TITLE
use start convention.

### DIFF
--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "watch": "tsc -w",
-    "start": "tsc -w",
+    "start": "tsc -p tsconfig-esm.json -w",
     "build": "tsc && tsc -p tsconfig-esm.json",
     "test": "mocha --require ts-node/register test/*.spec.*",
     "lint": "eslint \"{src,test}/**/*.{js,jsx,ts}\"",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,8 +19,7 @@
   ],
   "scripts": {
     "watch": "tsc -w",
-    "start": "tsc -w",
-    "start-nir": "tsc -w -p tsconfig-dev.json",
+    "start": "tsc -w -p tsconfig-dev.json",
     "build": "tsc && tsc -p tsconfig-esm.json",
     "test": "mocha --require ts-node/register test/*.spec.*",
     "lint": "eslint \"{src,test}/**/*.{js,jsx,ts}\"",


### PR DESCRIPTION
Why?
Watch wasn't configured correctly and unified in all packages so people were not sure how to work. 

What?
Unified the watch script. Using `start` because it's the convention for all create-react-app projects so everyone are used to it. 


After the Lerna cleanup I did earlier, the new flow for every developer is now:

1. `npm install`
2. `npm build`
3. `npm start` on each package you care about
4. Happy coding