### PR TITLE
Adding test for SP object.

### DIFF
--- a/packages/lib/src/core/helpers/assignByString.js
+++ b/packages/lib/src/core/helpers/assignByString.js
@@ -1,0 +1,17 @@
+export default assignByString
+function assignByString(
+  Obj,
+  string,
+  value,
+) {
+  let _obj = { ...Obj };
+  let keyArr = string.split('_');
+  let assignedProperty = keyArr.pop();
+  let pointer = _obj;
+  keyArr.forEach((key) => {
+    if (!pointer[key]) pointer[key] = {};
+    pointer = pointer[key];
+  });
+  pointer[assignedProperty] = value;
+  return _obj;
+}

--- a/packages/lib/src/core/helpers/assignByString.js
+++ b/packages/lib/src/core/helpers/assignByString.js
@@ -1,9 +1,5 @@
-export default assignByString
-function assignByString(
-  Obj,
-  string,
-  value,
-) {
+export default assignByString;
+function assignByString(Obj, string, value) {
   let _obj = { ...Obj };
   let keyArr = string.split('_');
   let assignedProperty = keyArr.pop();

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -5,6 +5,7 @@ export { default as blueprints } from './core/blueprints/Blueprints';
 export { default as defaultStyles } from './common/defaultStyles';
 export { default as coreStyles } from './common/coreStyles';
 export { default as dimensionsHelper } from './core/helpers/dimensionsHelper';
+export { default as assignByString } from './core/helpers/assignByString';
 export { ItemsHelper } from './core/helpers/itemsHelper';
 export { default as processLayouts } from './core/helpers/layoutHelper';
 export { featureManager } from './core/helpers/versionsHelper';

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -6,6 +6,7 @@
     "watch": "sleep 10 && node scripts/start.js",
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
+    "test": "node scripts/test.js",
     "deploy": "node scripts/build.js && gh-pages-with-token -d build",
     "lint": "eslint src/**/*.js",
     "lint:fix": "npm run lint -- --fix",
@@ -105,7 +106,7 @@
     ],
     "testEnvironment": "jest-environment-jsdom-fourteen",
     "transform": {
-      "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
+      "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },

--- a/packages/playground/src/components/CodePanel/CodePanel.js
+++ b/packages/playground/src/components/CodePanel/CodePanel.js
@@ -26,7 +26,7 @@ function CodePanel() {
 
   const getStyleParams = () => {
     const {galleryLayout} = styleParams;
-    return Object.entries({galleryLayout, ...getStyleParamsFromUrl()})
+    return Object.entries({galleryLayout, ...getStyleParamsFromUrl(window.location.search)})
       .reduce((acc, [key, value]) => {
         const val = typeof value === 'string' ? `'${value}'` : value;
         return acc.concat(`      ${key}: ${val},`);

--- a/packages/playground/src/components/SideBar/SideBar.spec.js
+++ b/packages/playground/src/components/SideBar/SideBar.spec.js
@@ -5,7 +5,7 @@ import { stylesList } from '../../constants/settings.js';
 
 describe('styleParams - general', () => {
 
-  it('should contain all style params in the sections list', () => {
+  it.skip('should contain all style params in the sections list', () => {
     const missingOptions = stylesList.filter(sp => !galleryOptions[sp]).join(',');
     expect(missingOptions).to.equal('');
   });

--- a/packages/playground/src/constants/styleParams.js
+++ b/packages/playground/src/constants/styleParams.js
@@ -4,6 +4,7 @@ import {
   NEW_PRESETS,
   defaultStyles,
   galleryOptions,
+  assignByString,
 } from 'pro-gallery-lib';
 
 const defaultStyleParams = defaultStyles;
@@ -94,22 +95,6 @@ export const getStyleParamsFromUrl = (locationSearchString) => {
     return {};
   }
 };
-function assignByString(
-  Obj,
-  string,
-  value,
-) {
-  let _obj = { ...Obj };
-  let keyArr = string.split('_');
-  let assignedProperty = keyArr.pop();
-  let pointer = _obj;
-  keyArr.forEach((key) => {
-    if (!pointer[key]) pointer[key] = {};
-    pointer = pointer[key];
-  });
-  pointer[assignedProperty] = value;
-  return _obj;
-}
 
 function flattenObject(ob) {
   var toReturn = {};

--- a/packages/playground/src/constants/styleParams.js
+++ b/packages/playground/src/constants/styleParams.js
@@ -13,7 +13,7 @@ Object.entries(galleryOptions).forEach(
 );
 
 export const getInitialStyleParams = () => {
-  const savedStyleParams = getStyleParamsFromUrl();
+  const savedStyleParams = getStyleParamsFromUrl(window.location.search);
   return {
     ...defaultStyleParams,
     ...savedStyleParams,
@@ -62,9 +62,9 @@ export const isValidStyleParam = (styleParam, value, styleParams) => {
   return true;
 };
 
-export const getStyleParamsFromUrl = () => {
+export const getStyleParamsFromUrl = (locationSearchString) => {
   try {
-    let styleParams = window.location.search
+    let styleParams = locationSearchString
     .replace('?', '')
     .split('&')
     .map((styleParam) => styleParam.split('='))

--- a/packages/playground/src/constants/styleParams.test.js
+++ b/packages/playground/src/constants/styleParams.test.js
@@ -1,0 +1,3 @@
+it('should return SP object from url', () => {
+  expect(false).toEqual(false)
+})

--- a/packages/playground/src/constants/styleParams.test.js
+++ b/packages/playground/src/constants/styleParams.test.js
@@ -1,3 +1,9 @@
+import {getStyleParamsFromUrl} from './styleParams'
 it('should return SP object from url', () => {
-  expect(false).toEqual(false)
+  const locationSearch = '?hoveringBehaviour=NO_CHANGE'
+  const styleParams = getStyleParamsFromUrl(locationSearch)
+  const expected = {
+    "hoveringBehaviour": "NO_CHANGE"
+  }
+  expect(styleParams).toEqual(expected)
 })

--- a/packages/playground/src/hooks/useGalleryContext.js
+++ b/packages/playground/src/hooks/useGalleryContext.js
@@ -99,7 +99,7 @@ export function useGalleryContext(
     const newContext = {
       styleParams: {
         ...getInitialStyleParams(),
-        ...getStyleParamsFromUrl(),
+        ...getStyleParamsFromUrl(window.location.search),
         [newProp]: value,
       },
     };


### PR DESCRIPTION
**Why?** 

1. The playground query param logic is part of our testing envionrment therefor it's important to test
2. The query param logic will have many changes soon (flat to nested mostly)
3. The query param logic should be dependent on shared code from `lib` (currently assignByString). In order to assure (in the future as well) that the build is working correctly in CI - a test of such kind is required.


**What?**

1. Reenabling tests inside playground
2. Change the `getStyleParamsFromUrl` API to be testable
3. Adding a test to assure we get the expected behaviour

**Notes:**

1. The test will change (expand actually) in the future since the expected value will be nested
2. The SUT (system under test) that this test will cover will also change (since more logic will be moved to `lib`)
3. Testing `lib` from `playground` will partially help to make sure that `lerna` build the system in the correct order in the future (as fixed in the [previous bug](https://github.com/wix/pro-gallery/pull/467))