### PR TITLE
Fix custom reporter

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,20 +10,20 @@ on:
     branches: [ master ]
 
 jobs:
-  # lint:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [14.16.1]
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Install and run lint
-  #     uses: actions/setup-node@v2
-  #     with:
-  #       node-version: ${{ matrix.node-version }}
-  #       cache: 'npm'
-  #   - run: npm install
-  #   - run: npm run lint
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.16.1]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install and run lint
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm install
+    - run: npm run lint
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.16.1]
-        test-script: ["ci:test-e2e-layouts"]
+        test-script: ["ci:test-unit", "ci:test-e2e-layouts","ci:test-e2e-styleParams", "ci:test-e2e-integration", "ci:test-e2e-ssr" ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -45,6 +45,7 @@ jobs:
       env:
         SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        TEST_NAME: ${{ matrix.test-script }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.16.1]
-        test-script: ["ci:test-unit", "ci:test-e2e-layouts","ci:test-e2e-styleParams", "ci:test-e2e-integration", "ci:test-e2e-ssr" ]
+        test-script: ["ci:test-e2e-layouts"]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -49,7 +49,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [lint, tests]
+    needs: [tests]
     strategy:
       matrix:
         node-version: [14.16.1]
@@ -89,7 +89,7 @@ jobs:
   update-playground:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs: [lint, tests]
+    needs: [tests]
     strategy:
       matrix:
         node-version: [14.16.1]

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,20 +10,20 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.16.1]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install and run lint
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm install
-    - run: npm run lint
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [14.16.1]
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Install and run lint
+  #     uses: actions/setup-node@v2
+  #     with:
+  #       node-version: ${{ matrix.node-version }}
+  #       cache: 'npm'
+  #   - run: npm install
+  #   - run: npm run lint
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - run: printenv
     - run: npm install
     - run: npm run build
     - run: npm run ${{ matrix.test-script }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -38,7 +38,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: printenv
     - run: npm install
     - run: npm run build
     - run: npm run ${{ matrix.test-script }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -49,7 +49,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [tests]
+    needs: [lint, tests]
     strategy:
       matrix:
         node-version: [14.16.1]
@@ -89,7 +89,7 @@ jobs:
   update-playground:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs: [tests]
+    needs: [lint, tests]
     strategy:
       matrix:
         node-version: [14.16.1]

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -41,6 +41,9 @@ jobs:
     - run: npm install
     - run: npm run build
     - run: npm run ${{ matrix.test-script }}
+      env:
+        SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+        SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -85,7 +85,8 @@
       "\\.(css|less|sass|scss)$": "<rootDir>/tests/drivers/mocks/stylesImportMock.js"
     },
     "reporters": [
-      "default"
+      "default",
+      "<rootDir>/tests/drivers/customReporter.js"
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -10,7 +10,7 @@ const formatSubDomain = (branch) => {
 function getDomain(branchName, testName, gitSha) {
   const uniqueJobId = [branchName, testName, gitSha]
     .join('-')
-    .substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:
+    .substring(0, 62); // max domain length is 255. chopping string from the SHA so the doamin will look like this:
   return `${formatSubDomain(uniqueJobId)}.pro-gallery-report.surge.sh/`;
 }
 

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -14,9 +14,9 @@ class DiffsReporter {
   }
   onRunComplete(contexts, results) {
     //          feature-name     82b582fb    ci:test-e2e-layouts
-    const { CI, GITHUB_HEAD_REF, GITHUB_SHA, TEST_NAME } = process.env;
+    const { CI, GITHUB_HEAD_REF, TEST_NAME } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
-    const uniqueJobId = [branchName, TEST_NAME, GITHUB_SHA]
+    const uniqueJobId = [branchName, TEST_NAME]
       .join('-')
       .substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
 

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -16,15 +16,6 @@ class DiffsReporter {
     //          feature-name     82b582fb    ci:test-e2e-layouts
     const { CI, GITHUB_HEAD_REF, TEST_NAME } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
-    const uniqueJobId = [branchName, TEST_NAME]
-      .join('-')
-      .substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
-
-    // This ensures that I will not overwrite any diff written by parallel tasks. If a new commit is added a new SHA is generated makes it easier to compare between the same commits in each PR.
-    const domain = `${formatSubDomain(
-      uniqueJobId
-    )}.pro-gallery-report.surge.sh/`;
-    console.log(`Will publish test report on failues to:${domain}`);
     if (!CI) {
       console.log('Not in CI, skipping generating and publishing test report');
       return;
@@ -37,8 +28,17 @@ class DiffsReporter {
           hidePassing: true,
         });
         const reportPath = path.resolve(process.cwd(), 'jest-stare');
+        const uniqueJobId = [branchName, TEST_NAME]
+          .join('-')
+          .substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
+
+        // This ensures that I will not overwrite any diff written by parallel tasks. If a new commit is added a new SHA is generated makes it easier to compare between the same commits in each PR.
+        const domain = `${formatSubDomain(
+          uniqueJobId
+        )}.pro-gallery-report.surge.sh/`;
+        console.log(`Will publish test report on failues to:${domain}`);
         exec(`npx surge --project ${reportPath} --domain ${domain}`);
-        console.log('report published successfully');
+        console.log('publish report successfully');
       } catch (error) {
         console.log('Error publishing reporter: ', error);
         process.exit(1);

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -13,14 +13,14 @@ class DiffsReporter {
     this._options = options;
   }
   onRunComplete(contexts, results) {
-    const { CI, GITHUB_REF } = process.env;
+    const { CI, GITHUB_HEAD_REF } = process.env;
     if (!CI) {
       console.log('Not in CI, skipping generating and publishing test report');
       return;
     }
     if (results.numFailedTests && results.snapshot.unmatched) {
       try {
-        const branchName = GITHUB_REF.split('/').pop();
+        const branchName = GITHUB_HEAD_REF || 'master'
         jestStareProcessor(results, {
           reportTitle: branchName,
           reportHeadline: '',

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -13,11 +13,15 @@ class DiffsReporter {
     this._options = options;
   }
   onRunComplete(contexts, results) {
+    //          feature-name     82b582fb    ci:test-e2e-layouts
     const { CI, GITHUB_HEAD_REF, GITHUB_SHA, GITHUB_JOB } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
     const uniqueJobId = [branchName,GITHUB_JOB, GITHUB_SHA]
       .join('-')
       .substring(0, 150) // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
+
+
+    // This ensures that I will not overwrite any diff written by parallel tasks. If a new commit is added a new SHA is generated makes it easier to compare between the same commits in each PR.
     const domain = `${formatSubDomain(
       uniqueJobId
     )}.pro-gallery-report.surge.sh/`;

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -3,8 +3,8 @@ const path = require('path');
 const jestStareProcessor = require('jest-stare');
 
 const exec = (cmd) => execSync(cmd, { stdio: 'inherit' });
-const formatBranchName = (branch) => {
-  return branch.replace(/[.]|_/g, '-').toLowerCase();
+const formatSubDomain = (branch) => {
+  return branch.replace(/[.]|_|[:]/g, '-').toLowerCase();
 };
 
 class DiffsReporter {
@@ -13,11 +13,13 @@ class DiffsReporter {
     this._options = options;
   }
   onRunComplete(contexts, results) {
-    const { CI, GITHUB_HEAD_REF, GITHUB_SHA } = process.env;
+    const { CI, GITHUB_HEAD_REF, GITHUB_SHA, GITHUB_JOB } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
-    const branchTriggertingCommit = `${branchName}-${GITHUB_SHA}`.substring(0, 100) // chopping string from the SHA and not the branch name.
-    const domain = `${formatBranchName(
-      branchTriggertingCommit
+    const uniqueJobId = [branchName,GITHUB_JOB, GITHUB_SHA]
+      .join('-')
+      .substring(0, 150) // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
+    const domain = `${formatSubDomain(
+      uniqueJobId
     )}.pro-gallery-report.surge.sh/`;
     console.log(`Will publish test report on failues to:${domain}`);
     if (!CI) {

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -14,13 +14,13 @@ class DiffsReporter {
   }
   onRunComplete(contexts, results) {
     const { CI, GITHUB_HEAD_REF } = process.env;
+    const branchName = GITHUB_HEAD_REF || 'master';
     if (!CI) {
       console.log('Not in CI, skipping generating and publishing test report');
       return;
     }
     if (results.numFailedTests && results.snapshot.unmatched) {
       try {
-        const branchName = GITHUB_HEAD_REF || 'master'
         jestStareProcessor(results, {
           reportTitle: branchName,
           reportHeadline: '',

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -42,6 +42,7 @@ class DiffsReporter {
         console.log('report published successfully')
       } catch (error) {
         console.log('Error publishing reporter: ', error);
+        process.exit(1);
       }
     }
   }

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -14,11 +14,11 @@ class DiffsReporter {
   }
   onRunComplete(contexts, results) {
     //          feature-name     82b582fb    ci:test-e2e-layouts
-    const { CI, GITHUB_HEAD_REF, GITHUB_SHA, GITHUB_JOB } = process.env;
+    const { CI, GITHUB_HEAD_REF, GITHUB_SHA, TEST_NAME } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
-    const uniqueJobId = [branchName, GITHUB_JOB, GITHUB_SHA]
+    const uniqueJobId = [branchName, TEST_NAME, GITHUB_SHA]
       .join('-')
-      .substring(0, 150); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
+      .substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
 
     // This ensures that I will not overwrite any diff written by parallel tasks. If a new commit is added a new SHA is generated makes it easier to compare between the same commits in each PR.
     const domain = `${formatSubDomain(

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -16,10 +16,9 @@ class DiffsReporter {
     //          feature-name     82b582fb    ci:test-e2e-layouts
     const { CI, GITHUB_HEAD_REF, GITHUB_SHA, GITHUB_JOB } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
-    const uniqueJobId = [branchName,GITHUB_JOB, GITHUB_SHA]
+    const uniqueJobId = [branchName, GITHUB_JOB, GITHUB_SHA]
       .join('-')
-      .substring(0, 150) // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
-
+      .substring(0, 150); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
 
     // This ensures that I will not overwrite any diff written by parallel tasks. If a new commit is added a new SHA is generated makes it easier to compare between the same commits in each PR.
     const domain = `${formatSubDomain(
@@ -39,7 +38,7 @@ class DiffsReporter {
         });
         const reportPath = path.resolve(process.cwd(), 'jest-stare');
         exec(`npx surge --project ${reportPath} --domain ${domain}`);
-        console.log('report published successfully')
+        console.log('report published successfully');
       } catch (error) {
         console.log('Error publishing reporter: ', error);
         process.exit(1);

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -13,8 +13,13 @@ class DiffsReporter {
     this._options = options;
   }
   onRunComplete(contexts, results) {
-    const { CI, GITHUB_HEAD_REF } = process.env;
+    const { CI, GITHUB_HEAD_REF, GITHUB_SHA } = process.env;
     const branchName = GITHUB_HEAD_REF || 'master';
+    const branchTriggertingCommit = `${branchName}-${GITHUB_SHA}`.substring(0, 100) // chopping string from the SHA and not the branch name.
+    const domain = `${formatBranchName(
+      branchTriggertingCommit
+    )}.pro-gallery-report.surge.sh/`;
+    console.log(`Will publish test report on failues to:${domain}`);
     if (!CI) {
       console.log('Not in CI, skipping generating and publishing test report');
       return;
@@ -27,11 +32,8 @@ class DiffsReporter {
           hidePassing: true,
         });
         const reportPath = path.resolve(process.cwd(), 'jest-stare');
-        const domain = `${formatBranchName(
-          branchName
-        )}.pro-gallery-report.surge.sh/`;
-        console.log(`Publishing test report to ${domain}`);
         exec(`npx surge --project ${reportPath} --domain ${domain}`);
+        console.log('report published successfully')
       } catch (error) {
         console.log('Error publishing reporter: ', error);
       }

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -8,9 +8,7 @@ const formatSubDomain = (branch) => {
 };
 
 function getDomain(branchName, testName, gitSha) {
-  const uniqueJobId = [branchName, testName, gitSha]
-    .join('-')
-    .substring(0, 62); // max domain length is 255. chopping string from the SHA so the doamin will look like this:
+  const uniqueJobId = [branchName, testName, gitSha].join('-').substring(0, 62); // max domain length is 255. chopping string from the SHA so the doamin will look like this:
   return `${formatSubDomain(uniqueJobId)}.pro-gallery-report.surge.sh/`;
 }
 

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -1,0 +1,41 @@
+const execSync = require('child_process').execSync;
+const path = require('path');
+const jestStareProcessor = require('jest-stare');
+
+const exec = (cmd) => execSync(cmd, { stdio: 'inherit' });
+const formatBranchName = (branch) => {
+  return branch.replace(/[.]|_/g, '-').toLowerCase();
+};
+
+class DiffsReporter {
+  constructor(globalConfig, options) {
+    this._globalConfig = globalConfig;
+    this._options = options;
+  }
+  onRunComplete(contexts, results) {
+    const { CI, GITHUB_REF } = process.env;
+    if (!CI) {
+      console.log('Not in CI, skipping generating and publishing test report');
+      return;
+    }
+    if (results.numFailedTests && results.snapshot.unmatched) {
+      try {
+        const branchName = GITHUB_REF.split('/').pop();
+        jestStareProcessor(results, {
+          reportTitle: branchName,
+          reportHeadline: '',
+          hidePassing: true,
+        });
+        const reportPath = path.resolve(process.cwd(), 'jest-stare');
+        const domain = `${formatBranchName(
+          branchName
+        )}.pro-gallery-report.surge.sh/`;
+        console.log(`Publishing test report to ${domain}`);
+        exec(`npx surge --project ${reportPath} --domain ${domain}`);
+      } catch (error) {
+        console.log('Error publishing reporter: ', error);
+      }
+    }
+  }
+}
+module.exports = DiffsReporter;

--- a/packages/gallery/tests/drivers/customReporter.js
+++ b/packages/gallery/tests/drivers/customReporter.js
@@ -28,9 +28,7 @@ class DiffsReporter {
           hidePassing: true,
         });
         const reportPath = path.resolve(process.cwd(), 'jest-stare');
-        const uniqueJobId = [branchName, TEST_NAME]
-          .join('-')
-          .substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
+        const uniqueJobId = [branchName, TEST_NAME].join('-').substring(0, 100); // max domain length is 255. chopping string from the SHA so the doamin will look like this:  http://create-blueprints-package-test-e2e-layout-4acf916a430baadc.pro-gallery-report.surge.sh/
 
         // This ensures that I will not overwrite any diff written by parallel tasks. If a new commit is added a new SHA is generated makes it easier to compare between the same commits in each PR.
         const domain = `${formatSubDomain(
@@ -38,7 +36,7 @@ class DiffsReporter {
         )}.pro-gallery-report.surge.sh/`;
         console.log(`Will publish test report on failues to:${domain}`);
         exec(`npx surge --project ${reportPath} --domain ${domain}`);
-        console.log('publish report successfully');
+        console.log(`publish report successfully. Click here: ${domain}`);
       } catch (error) {
         console.log('Error publishing reporter: ', error);
         process.exit(1);

--- a/packages/gallery/tests/drivers/pptrDriver.js
+++ b/packages/gallery/tests/drivers/pptrDriver.js
@@ -46,7 +46,7 @@ export default class galleryDriver {
   }
 
   async navigate(styleParams) {
-    const pageUrl = this.getPageUrl(styleParams);
+    const pageUrl = styleParams.galleryLayout === 10 ? 'https://img.bleacherreport.net/img/images/photos/003/875/045/f747eca6d77ef4822de3a4c98bb4324e_crop_exact.jpg?h=646&w=970&q=70&crop_x=center&crop_y=top' : this.getPageUrl(styleParams);
     await this.page.goto(pageUrl, { waitUntil: 'networkidle2' });
     await this.scrollInteraction();
     await this.page.waitFor(500);

--- a/packages/gallery/tests/drivers/pptrDriver.js
+++ b/packages/gallery/tests/drivers/pptrDriver.js
@@ -46,10 +46,10 @@ export default class galleryDriver {
   }
 
   async navigate(styleParams) {
-    const pageUrl =
-      styleParams.galleryLayout === 10
-        ? 'https://img.bleacherreport.net/img/images/photos/003/875/045/f747eca6d77ef4822de3a4c98bb4324e_crop_exact.jpg?h=646&w=970&q=70&crop_x=center&crop_y=top'
-        : this.getPageUrl(styleParams);
+    if (styleParams.galleryLayout === 10) {
+      styleParams.galleryLayout = 5;
+    }
+    const pageUrl = this.getPageUrl(styleParams);
     await this.page.goto(pageUrl, { waitUntil: 'networkidle2' });
     await this.scrollInteraction();
     await this.page.waitFor(500);

--- a/packages/gallery/tests/drivers/pptrDriver.js
+++ b/packages/gallery/tests/drivers/pptrDriver.js
@@ -46,9 +46,6 @@ export default class galleryDriver {
   }
 
   async navigate(styleParams) {
-    if (styleParams.galleryLayout === 10) {
-      styleParams.galleryLayout = 5;
-    }
     const pageUrl = this.getPageUrl(styleParams);
     await this.page.goto(pageUrl, { waitUntil: 'networkidle2' });
     await this.scrollInteraction();

--- a/packages/gallery/tests/drivers/pptrDriver.js
+++ b/packages/gallery/tests/drivers/pptrDriver.js
@@ -46,7 +46,10 @@ export default class galleryDriver {
   }
 
   async navigate(styleParams) {
-    const pageUrl = styleParams.galleryLayout === 10 ? 'https://img.bleacherreport.net/img/images/photos/003/875/045/f747eca6d77ef4822de3a4c98bb4324e_crop_exact.jpg?h=646&w=970&q=70&crop_x=center&crop_y=top' : this.getPageUrl(styleParams);
+    const pageUrl =
+      styleParams.galleryLayout === 10
+        ? 'https://img.bleacherreport.net/img/images/photos/003/875/045/f747eca6d77ef4822de3a4c98bb4324e_crop_exact.jpg?h=646&w=970&q=70&crop_x=center&crop_y=top'
+        : this.getPageUrl(styleParams);
     await this.page.goto(pageUrl, { waitUntil: 'networkidle2' });
     await this.scrollInteraction();
     await this.page.waitFor(500);

--- a/packages/gallery/tests/drivers/pptrDriver.js
+++ b/packages/gallery/tests/drivers/pptrDriver.js
@@ -46,6 +46,9 @@ export default class galleryDriver {
   }
 
   async navigate(styleParams) {
+    if (styleParams.galleryLayout === 10) {
+      styleParams.galleryLayout = 5;
+    }
     const pageUrl = this.getPageUrl(styleParams);
     await this.page.goto(pageUrl, { waitUntil: 'networkidle2' });
     await this.scrollInteraction();


### PR DESCRIPTION
the diff is showing a new file so it's harder to see the changes between now and the [old reporter](https://github.com/wix/pro-gallery/blob/v3/packages/gallery/tests/drivers/customReporter.js)

### Why?
We need to see the diffs in failing builds

### What?
1. Bring back reporter
2. Pass secrert varaibles to the process using the reporter (so we can deploy using `surge`
3. Use the correct ENV variable for creating a unique domain name for every branch (so we construct correct subdomain)

### Improvements from old reporter:

1. If two concurrent tasks (`ci:test-e2e-layouts` and `ci:test-e2e-styleParams` for example) are failing with diffs, they now don't overwrite each other since the test name (`ci:test-e2e-layouts` for example) is passed to the reporter now
3. If you add a commit that fixes some off the diffs, you can see the new diffs and compare it to the old commit (since the subdomain contains part of the `GITHUB_SHA`)
4. When the reporter fails from some reason, the tests won't be stuck in an infinite loop (because I `process.exit(1) inside the `catch` block



The diffs URL format is now `${BRANCH_NAME}-${TEST_TASK_NAME}-${GIT_SHA}.pro-gallery-report.surge.sh/` for example - http://reporter-for-good-ci-test-e2e-layouts-aa5117ce38566791f9f7966f.pro-gallery-report.surge.sh/

Thanks @IzaacAyelin  for clarifying some of the old implementation. 