### PR TITLE
using browserify to build a standalone validate function

### DIFF
--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const browserify = require('browserify');
+// const browserify = require('browserify');
+import browserify from 'browserify';
 const fs = require('fs');
 const Ajv = require('ajv');
 
@@ -26,6 +27,8 @@ function writeES5StandaloneValidateMethod() {
     .transform('babelify', { global: true, presets: ['@babel/preset-env'] })
     .bundle()
     .pipe(fs.createWriteStream(browserifyBundle));
+
+  fs.rmSync(tempFilePath);
 }
 
 function buildValidationFunction(schema) {

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,26 +1,47 @@
-const path = require("path");
-const fs = require("fs");
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
 
-const { transformSync } =require("@babel/core")
-const Ajv = require("ajv")
+// const { transformSync } =require("@babel/core")
+const Ajv = require('ajv');
 
-const getSchemaFromTypes = require('./generateJSONSchemaFromTypes')
+const getSchemaFromTypes = require('./generateJSONSchemaFromTypes');
 
 function writeES5StandaloneValidateMethod() {
-  const moduleCode = buildValidationFunction(getSchemaFromTypes())
-  const {code} = transformSync(moduleCode, {});
-  const es5CompatibleCode = `/* eslint-disable */ ${code} /* eslint-enable */`
-  const typeValidatorDir = path.join(__dirname, '../src/components/gallery/typeValidator')
-  fs.writeFileSync(path.join(typeValidatorDir,'/standaloneValidateCode.js'), es5CompatibleCode, {encoding: 'utf-8'})
+  const moduleCode = buildValidationFunction(getSchemaFromTypes());
+  // const {code} = transformSync(moduleCode, {});
+  // const es5CompatibleCode = `/* eslint-disable */ ${code} /* eslint-enable */`
+  const tempFilePath = path.join(__dirname, 'temp.js');
+  fs.writeFileSync(tempFilePath, `module.exports=${moduleCode}`);
+  // fs.writeFileSync(tempFilePath, moduleCode)
+  const typeValidatorDir = path.join(
+    __dirname,
+    '../src/components/gallery/typeValidator'
+  );
+  const standaloneValidateCodePath = path.join(
+    typeValidatorDir,
+    '/standaloneValidateCode.js'
+  );
+  // fs.writeFileSync(standaloneValidateCodePath, `module.exports=${moduleCode}`)
+  // const browserifyBundle = path.join(typeValidatorDir,'/browserify.js')
+  const browserifyBundle = standaloneValidateCodePath;
+  execSync(
+    `node node_modules/.bin/browserify -t [ babelify --presets [ @babel/preset-env ] ] --standalone nirnaor ${tempFilePath} > ${browserifyBundle}`
+  );
+  // fs.writeFileSync(standaloneValidateCodePath, moduleCode, {encoding: 'utf-8'})
 }
 
 function buildValidationFunction(schema) {
-  const ajv = new Ajv({messages: true, verbose: true, code: {source: true, es5: true}})
-  const standaloneCode = require("ajv/dist/standalone").default
-  ajv.addSchema(schema, 'testSchema')
-  const validate = ajv.compile(schema, 'testSchema')
-  let moduleCode = standaloneCode(ajv, validate)
-  return moduleCode
+  const ajv = new Ajv({
+    messages: true,
+    verbose: true,
+    code: { source: true, es5: true },
+  });
+  const standaloneCode = require('ajv/dist/standalone').default;
+  ajv.addSchema(schema, 'testSchema');
+  const validate = ajv.compile(schema, 'testSchema');
+  let moduleCode = standaloneCode(ajv, validate);
+  return moduleCode;
 }
 
-writeES5StandaloneValidateMethod()
+writeES5StandaloneValidateMethod();

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const browserify = require('browserify');
-// import browserify from 'browserify';
 const fs = require('fs');
 const Ajv = require('ajv');
 
@@ -8,12 +7,8 @@ const getSchemaFromTypes = require('./generateJSONSchemaFromTypes');
 
 function writeES5StandaloneValidateMethod() {
   const code = buildValidationFunction(getSchemaFromTypes());
-  // const moduleCode = `/* eslint-disable */ ${code} /* eslint-enable */`;
   const tempFilePath = path.join(__dirname, 'temp.js');
-  fs.writeFileSync(
-    tempFilePath,
-    `/* eslint-disable */ module.exports=${code}/* eslint-enable */`
-  );
+  fs.writeFileSync(tempFilePath, `module.exports=${code}`);
   const typeValidatorDir = path.join(
     __dirname,
     '../src/components/gallery/typeValidator'

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,6 +1,8 @@
 const path = require('path');
+var browserify = require('browserify');
+// import browserify from 'browserify'
 const fs = require('fs');
-const { execSync } = require('child_process');
+// const { execSync } = require('child_process');
 
 // const { transformSync } =require("@babel/core")
 const Ajv = require('ajv');
@@ -25,9 +27,14 @@ function writeES5StandaloneValidateMethod() {
   // fs.writeFileSync(standaloneValidateCodePath, `module.exports=${moduleCode}`)
   // const browserifyBundle = path.join(typeValidatorDir,'/browserify.js')
   const browserifyBundle = standaloneValidateCodePath;
-  execSync(
-    `node node_modules/.bin/browserify -t [ babelify --presets [ @babel/preset-env ] ] --standalone nirnaor ${tempFilePath} > ${browserifyBundle}`
-  );
+  browserify(tempFilePath, { standalone: 'nirnaor' })
+    .transform('babelify', { global: true, presets: ['@babel/preset-env'] })
+    .bundle()
+    .pipe(fs.createWriteStream(browserifyBundle));
+
+  // execSync(
+  //   `node node_modules/.bin/browserify -t [ babelify --presets [ @babel/preset-env ] ] --standalone nirnaor ${tempFilePath} > ${browserifyBundle}`
+  // );
   // fs.writeFileSync(standaloneValidateCodePath, moduleCode, {encoding: 'utf-8'})
 }
 

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -7,9 +7,12 @@ const getSchemaFromTypes = require('./generateJSONSchemaFromTypes');
 
 function writeES5StandaloneValidateMethod() {
   const code = buildValidationFunction(getSchemaFromTypes());
-  const moduleCode = `/* eslint-disable */ ${code} /* eslint-enable */`;
+  // const moduleCode = `/* eslint-disable */ ${code} /* eslint-enable */`;
   const tempFilePath = path.join(__dirname, 'temp.js');
-  fs.writeFileSync(tempFilePath, `module.exports=${moduleCode}`);
+  fs.writeFileSync(
+    tempFilePath,
+    `/* eslint-disable */ module.exports=${code}/* eslint-enable */`
+  );
   const typeValidatorDir = path.join(
     __dirname,
     '../src/components/gallery/typeValidator'

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const browserify = require('browserify');
+// import browserify from 'browserify';
 const fs = require('fs');
 const Ajv = require('ajv');
 
@@ -22,12 +23,16 @@ function writeES5StandaloneValidateMethod() {
     '/standaloneValidateCode.js'
   );
   const browserifyBundle = standaloneValidateCodePath;
+  const fileWriter = fs.createWriteStream(browserifyBundle);
   browserify(tempFilePath, { standalone: 'nirnaor' })
     .transform('babelify', { global: true, presets: ['@babel/preset-env'] })
     .bundle()
-    .pipe(fs.createWriteStream(browserifyBundle));
+    .pipe(fileWriter);
 
-  fs.rmSync(tempFilePath);
+  fileWriter.on('finish', function () {
+    console.log('finished writing the browserify file');
+    fs.rmSync(tempFilePath);
+  });
 }
 
 function buildValidationFunction(schema) {

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,21 +1,15 @@
 const path = require('path');
-var browserify = require('browserify');
-// import browserify from 'browserify'
+const browserify = require('browserify');
 const fs = require('fs');
-// const { execSync } = require('child_process');
-
-// const { transformSync } =require("@babel/core")
 const Ajv = require('ajv');
 
 const getSchemaFromTypes = require('./generateJSONSchemaFromTypes');
 
 function writeES5StandaloneValidateMethod() {
-  const moduleCode = buildValidationFunction(getSchemaFromTypes());
-  // const {code} = transformSync(moduleCode, {});
-  // const es5CompatibleCode = `/* eslint-disable */ ${code} /* eslint-enable */`
+  const code = buildValidationFunction(getSchemaFromTypes());
+  const moduleCode = `/* eslint-disable */ ${code} /* eslint-enable */`;
   const tempFilePath = path.join(__dirname, 'temp.js');
   fs.writeFileSync(tempFilePath, `module.exports=${moduleCode}`);
-  // fs.writeFileSync(tempFilePath, moduleCode)
   const typeValidatorDir = path.join(
     __dirname,
     '../src/components/gallery/typeValidator'
@@ -24,18 +18,11 @@ function writeES5StandaloneValidateMethod() {
     typeValidatorDir,
     '/standaloneValidateCode.js'
   );
-  // fs.writeFileSync(standaloneValidateCodePath, `module.exports=${moduleCode}`)
-  // const browserifyBundle = path.join(typeValidatorDir,'/browserify.js')
   const browserifyBundle = standaloneValidateCodePath;
   browserify(tempFilePath, { standalone: 'nirnaor' })
     .transform('babelify', { global: true, presets: ['@babel/preset-env'] })
     .bundle()
     .pipe(fs.createWriteStream(browserifyBundle));
-
-  // execSync(
-  //   `node node_modules/.bin/browserify -t [ babelify --presets [ @babel/preset-env ] ] --standalone nirnaor ${tempFilePath} > ${browserifyBundle}`
-  // );
-  // fs.writeFileSync(standaloneValidateCodePath, moduleCode, {encoding: 'utf-8'})
 }
 
 function buildValidationFunction(schema) {

--- a/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
+++ b/packages/gallery/buildScripts/buildRuntimeValidateFunctionFromTypes.js
@@ -1,6 +1,5 @@
 const path = require('path');
-// const browserify = require('browserify');
-import browserify from 'browserify';
+const browserify = require('browserify');
 const fs = require('fs');
 const Ajv = require('ajv');
 

--- a/packages/gallery/eslintConfig.js
+++ b/packages/gallery/eslintConfig.js
@@ -11,6 +11,6 @@ module.exports = {
     'plugin:prettier/recommended',
     'prettier/@typescript-eslint',
   ],
-  ignorePatterns: ['versionLogger.js'],
+  ignorePatterns: ['versionLogger.js', 'standaloneValidateCode.js'],
   rules: {},
 };

--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.3",
+    "@babel/core": "7.4.3",
     "@babel/preset-env": "^7.5.5",
     "@types/react": "^16.14.6",
     "@typescript-eslint/eslint-plugin": "^4.8.1",

--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -51,10 +51,14 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
     "@types/react": "^16.14.6",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "ajv": "^8.6.0",
+    "babelify": "^10.0.0",
+    "browserify": "^17.0.0",
     "chai": "^4.2.0",
     "chai-spies": "^0.7.1",
     "concurrently": "^6.1.0",

--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -51,8 +51,8 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.15.0",
-    "@babel/preset-env": "^7.15.0",
+    "@babel/core": "^7.4.3",
+    "@babel/preset-env": "^7.5.5",
     "@types/react": "^16.14.6",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/packages/gallery/src/components/gallery/typeValidator/validateTypes.ts
+++ b/packages/gallery/src/components/gallery/typeValidator/validateTypes.ts
@@ -2,7 +2,7 @@ import typeErrorsUI from './typeErrorsUI';
 import { StyleParams } from '../styles.d';
 const validateFunc = require('./standaloneValidateCode'); //eslint-disable-line
 
-function validate(data?: StyleParams) {
+function validate(data?: StyleParams): any[] {
   validateFunc(data);
   return validateFunc.errors || [];
 }

--- a/packages/gallery/src/components/gallery/typeValidator/validateTypes.ts
+++ b/packages/gallery/src/components/gallery/typeValidator/validateTypes.ts
@@ -2,7 +2,7 @@ import typeErrorsUI from './typeErrorsUI';
 import { StyleParams } from '../styles.d';
 const validateFunc = require('./standaloneValidateCode'); //eslint-disable-line
 
-function validate(data?: StyleParams): any[] {
+function validate(data?: StyleParams): Record<string, unknown>[] {
   validateFunc(data);
   return validateFunc.errors || [];
 }


### PR DESCRIPTION
### Why?

1. AJV [standalone](@babel/core) does not really stand [alone](https://github.com/ajv-validator/ajv/issues/1523#issuecomment-810855167) since the generated module is `requiring` some of the `runtime` folder of AJV. 
2. That runtime folder isn't built in es5, and even when I forked it - it requires internal modules [inside of it](https://github.com/ajv-validator/ajv/blob/master/lib/runtime/equal.ts#L2)

I needed a solution that will

- Create a REAL standalone bundle
- Contain all the dependencies relevant to the validate function
- ES5 compatible

### What?
[Browserify](https://browserify.org/) does exactly that. Even tough it's a pretty old tool- it fits the needs described above
Ignoring lint for the bundled file