### PR TITLE
remove pointer events

### DIFF
--- a/packages/gallery/src/components/styles/gallery.scss
+++ b/packages/gallery/src/components/styles/gallery.scss
@@ -502,10 +502,6 @@ div.pro-gallery {
         }
       }
 
-      .item-hover-flex-container{
-        pointer-events: none;
-      }
-
       .gallery-item-hover {
         white-space: initial;
         position: absolute;


### PR DESCRIPTION
Initially, we wanted the magnifying glass to work even when there is a hover element.
that required me to add pointer-events: none to the hover CSS in order for the click event to pass through the hover and reach the magnification container and I didn't take into account the icons on the hover elements. maybe we should keep it this way (without the pointer event) and avoid this complication (this means the magnification will not work when there is a hover on the image)