### PR TITLE
fix first video playing when not needed

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -81,7 +81,7 @@ export class GalleryContainer extends React.Component {
   initializeScrollPosition() {
     if (this.props.activeIndex > 0) {
       this.scrollToItem(this.props.activeIndex, false, true, 0);
-      const currentItem = this.galleryStructure.items[this.props.activeIndex || 0];
+      const currentItem = this.galleryStructure.items[this.props.activeIndex];
       this.onGalleryScroll(currentItem.offset);
     }
   }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -78,14 +78,19 @@ export class GalleryContainer extends React.Component {
 
     //not sure if there needs to be a handleNEwGalleryStructure here with the intial state. currently looks like not
   }
+  initializeScrollPosition() {
+    if (this.props.activeIndex > 0) {
+      this.scrollToItem(this.props.activeIndex, false, true, 0);
+      const currentItem = this.galleryStructure.items[this.props.activeIndex || 0];
+      this.onGalleryScroll(currentItem.offset);
+    }
+  }
 
   componentDidMount() {
-    this.scrollToItem(this.props.activeIndex, false, true, 0);
+    this.initializeScrollPosition()
     this.handleNewGalleryStructure();
     this.eventsListener(GALLERY_CONSTS.events.APP_LOADED, {});
     this.videoScrollHelper.initializePlayState();
-    const currentItem = this.galleryStructure.items[this.props.activeIndex || 0];
-    this.videoScrollHelper.initScroll(currentItem.offset);
 
     try {
       if (typeof window.CustomEvent === 'function') {

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -84,6 +84,8 @@ export class GalleryContainer extends React.Component {
     this.handleNewGalleryStructure();
     this.eventsListener(GALLERY_CONSTS.events.APP_LOADED, {});
     this.videoScrollHelper.initializePlayState();
+    const currentItem = this.galleryStructure.items[this.props.activeIndex || 0];
+    this.videoScrollHelper.initScroll(currentItem.offset);
 
     try {
       if (typeof window.CustomEvent === 'function') {

--- a/packages/gallery/src/components/helpers/videoScrollHelperWrapper.js
+++ b/packages/gallery/src/components/helpers/videoScrollHelperWrapper.js
@@ -7,7 +7,6 @@ class VideoScrollHelperWrapper {
     this.setPlayingIdxState = setPlayingIdxState;
     this.handleEvent = () => {};
     this.onScroll = this.onScroll.bind(this);
-    this.initScroll = this.initScroll.bind(this);
     this.trigger = {
       SCROLL: this.onScroll,
       INIT_SCROLL: () => {},
@@ -15,13 +14,11 @@ class VideoScrollHelperWrapper {
     this.stop = () => {};
     this.initializePlayState = () => {};
   }
-  initScroll({ top, left }) {
+  onScroll({ top, left }) {
     this.top = top || this.top;
     this.left = left || this.left;
   }
-  onScroll({ top, left }) {
-    this.initScroll({ top, left });
-  }
+
   initVideoScrollHelperIfNeeded(galleryStructureData, items) {
     if (
       items.some(

--- a/packages/gallery/src/components/helpers/videoScrollHelperWrapper.js
+++ b/packages/gallery/src/components/helpers/videoScrollHelperWrapper.js
@@ -18,7 +18,6 @@ class VideoScrollHelperWrapper {
     this.top = top || this.top;
     this.left = left || this.left;
   }
-
   initVideoScrollHelperIfNeeded(galleryStructureData, items) {
     if (
       items.some(

--- a/packages/gallery/src/components/helpers/videoScrollHelperWrapper.js
+++ b/packages/gallery/src/components/helpers/videoScrollHelperWrapper.js
@@ -7,6 +7,7 @@ class VideoScrollHelperWrapper {
     this.setPlayingIdxState = setPlayingIdxState;
     this.handleEvent = () => {};
     this.onScroll = this.onScroll.bind(this);
+    this.initScroll = this.initScroll.bind(this);
     this.trigger = {
       SCROLL: this.onScroll,
       INIT_SCROLL: () => {},
@@ -14,9 +15,12 @@ class VideoScrollHelperWrapper {
     this.stop = () => {};
     this.initializePlayState = () => {};
   }
-  onScroll({ top, left }) {
+  initScroll({ top, left }) {
     this.top = top || this.top;
     this.left = left || this.left;
+  }
+  onScroll({ top, left }) {
+    this.initScroll({ top, left });
   }
   initVideoScrollHelperIfNeeded(galleryStructureData, items) {
     if (


### PR DESCRIPTION
**What** - initialize videoScrollHelperWrapper with the correct top/left values 
**why** - when activeIndex is not 0 the first video is still playing