### PR TITLE
new feature - image load animation

### DIFF
--- a/packages/gallery/src/components/item/imageItem.js
+++ b/packages/gallery/src/components/item/imageItem.js
@@ -114,6 +114,25 @@ class ImageItem extends React.Component {
     );
   }
 
+  getLoadTransitionStyle() {
+    const style = {};
+    const { loadTransition, loadTransitionDuration } = this.props.options?.behaviourParams?.item || {};
+    if (loadTransitionDuration && loadTransition && loadTransition !== GALLERY_CONSTS.loadTransition.NO_EFFECT) {
+      switch (loadTransition) {
+        case GALLERY_CONSTS.loadTransition.BLUR_OUT: {
+          style.transition = `filter ${loadTransitionDuration}ms`;
+          if (this.state.isHighResImageLoaded) {
+            style.filter = "blur(0px)";
+          } else {
+            style.filter = "blur(20px)";
+          }
+          break;
+        }
+      }
+    }
+    return style;
+  }
+
   getImageElement() {
     const {
       calculatedAlt,
@@ -153,6 +172,7 @@ class ImageItem extends React.Component {
             height: '100%',
           }
         : {};
+      const loadTransitionStyle = this.getLoadTransitionStyle();
 
       if (!isHighResImageLoaded && gotFirstScrollEvent && !isTransparent) {
         let preload = null;
@@ -177,6 +197,7 @@ class ImageItem extends React.Component {
                   ...imageSizing,
                   ...preloadStyles,
                   ...blockDownloadStyles,
+                  ...loadTransitionStyle,
                 }}
                 {...preloadProps}
               />
@@ -195,6 +216,7 @@ class ImageItem extends React.Component {
                   ...imageSizing,
                   ...preloadStyles,
                   ...blockDownloadStyles,
+                  ...loadTransitionStyle,
                 }}
                 {...preloadProps}
               />
@@ -224,6 +246,7 @@ class ImageItem extends React.Component {
           style={{
             ...imageSizing,
             ...blockDownloadStyles,
+            ...loadTransitionStyle,
             ...(!shouldRenderHighResImages && preloadStyles),
           }}
           {...imageProps}

--- a/packages/lib/src/common/constants/index.js
+++ b/packages/lib/src/common/constants/index.js
@@ -15,6 +15,7 @@ import infoType from './infoType';
 import isVertical from './isVertical';
 import itemClick from './itemClick';
 import layout, { isLayout } from './layout';
+import loadTransition, { isLoadTransition } from './loadTransition';
 import layoutDirection from './layoutDirection';
 import loadingMode from './loadingMode';
 import loadingWithColorMode from './loadingWithColorMode';
@@ -73,6 +74,8 @@ export default {
   itemClick,
   layout,
   isLayout,
+  loadTransition,
+  isLoadTransition,
   layoutDirection,
   loadingMode,
   loadingWithColorMode,

--- a/packages/lib/src/common/constants/loadTransition.js
+++ b/packages/lib/src/common/constants/loadTransition.js
@@ -1,0 +1,13 @@
+const LOAD_TRANSITIONS = {
+  NO_EFFECT: 0,
+  BLUR_OUT: 1,
+};
+
+const isLoadTransition = (layoutName) => (options) => {
+  return (
+    options.behaviourParams.item.loadTransition === LOAD_TRANSITIONS[layoutName]
+  );
+};
+
+export default LOAD_TRANSITIONS;
+export { isLoadTransition };

--- a/packages/lib/src/common/coreOptions.js
+++ b/packages/lib/src/common/coreOptions.js
@@ -5,6 +5,11 @@ const coreOptions = {
     gallerySpacing: 0,
     cropRatio: 1, // determine the ratio of the images when using grid (use 1 for squares grid)
   },
+  behaviourParams: {
+    item: {
+      loadTransitionDuration: 300,
+    },
+  },
   isRTL: false,
   isVertical: false,
   minItemSize: 120,

--- a/packages/lib/src/common/defaultOptions.js
+++ b/packages/lib/src/common/defaultOptions.js
@@ -15,6 +15,7 @@ const defaultOptions = mergeNestedObjects(coreOptions, {
       content: {
         magnificationValue: 2,
       },
+      loadTransitionDuration: 300,
     },
   },
   // adding

--- a/packages/lib/src/common/interfaces/behaviourParams.d.ts
+++ b/packages/lib/src/common/interfaces/behaviourParams.d.ts
@@ -8,6 +8,8 @@ export interface Item {
   video?: Video;
   overlay?: Overlay;
   content?: Content;
+  loadTransition?: 'NO_EFFECT' | 'BLUR_OUT';
+  loadTransitionDuration: number;
 }
 
 export interface Gallery {

--- a/packages/lib/src/settings/options/index.js
+++ b/packages/lib/src/settings/options/index.js
@@ -99,6 +99,7 @@ import autoSlideshowType from './autoSlideshowType';
 import autoSlideshowContinuousSpeed from './autoSlideshowContinuousSpeed';
 import behaviourParams_item_content_magnificationValue from './magnificationValue';
 import behaviourParams_item_loadTransition from './loadTransition';
+import behaviourParams_item_loadTransitionDuration from './loadTransitionDuration';
 
 export default {
   layoutParams_gallerySpacing,
@@ -202,6 +203,7 @@ export default {
   autoSlideshowContinuousSpeed,
   behaviourParams_item_content_magnificationValue,
   behaviourParams_item_loadTransition,
+  behaviourParams_item_loadTransitionDuration,
 };
 
 // TODO = add the options:

--- a/packages/lib/src/settings/options/index.js
+++ b/packages/lib/src/settings/options/index.js
@@ -98,6 +98,7 @@ import overlayPadding from './overlayPadding';
 import autoSlideshowType from './autoSlideshowType';
 import autoSlideshowContinuousSpeed from './autoSlideshowContinuousSpeed';
 import behaviourParams_item_content_magnificationValue from './magnificationValue';
+import behaviourParams_item_loadTransition from './loadTransition';
 
 export default {
   layoutParams_gallerySpacing,
@@ -200,6 +201,7 @@ export default {
   autoSlideshowType,
   autoSlideshowContinuousSpeed,
   behaviourParams_item_content_magnificationValue,
+  behaviourParams_item_loadTransition,
 };
 
 // TODO = add the options:

--- a/packages/lib/src/settings/options/loadTransition.js
+++ b/packages/lib/src/settings/options/loadTransition.js
@@ -1,0 +1,12 @@
+import { INPUT_TYPES } from '../utils/constants';
+import { default as GALLERY_CONSTS } from '../../common/constants';
+import { createOptions } from '../utils/utils';
+
+export default {
+  title: 'Image Load Transition',
+  description: `Set the type of transition used when image are loading and changing resolution`,
+  type: INPUT_TYPES.OPTIONS,
+  default: GALLERY_CONSTS.loadTransition.NO_EFFECT,
+  options: createOptions('loadTransition'),
+  isRelevant: () => true,
+};

--- a/packages/lib/src/settings/options/loadTransitionDuration.js
+++ b/packages/lib/src/settings/options/loadTransitionDuration.js
@@ -1,0 +1,14 @@
+import { INPUT_TYPES } from '../utils/constants';
+import { default as GALLERY_CONSTS } from '../../common/constants';
+
+export default {
+  title: 'Image Load Transition Duration',
+  description: `Set the length of the transition effect used when image are loading and changing resolution`,
+  type: INPUT_TYPES.NUMBER,
+  default: 300,
+  isRelevant: (options) => {
+    const loadTransition = options.behaviourParams_item_loadTransition;
+    return loadTransition !== GALLERY_CONSTS.loadTransition.NO_EFFECT;
+  },
+  isRelevantDescription: 'Set Image Load Transition First',
+};

--- a/packages/playground/src/constants/settings.js
+++ b/packages/playground/src/constants/settings.js
@@ -155,6 +155,8 @@ export const optionsBySection = {
     'slideAnimation',
     'oneColorAnimationColor',
     'slideTransition',
+    'behaviourParams_item_loadTransition',
+    'behaviourParams_item_loadTransitionDuration',
   ],
   [SECTIONS.IMAGE]: [
     // 'imageQuality',


### PR DESCRIPTION
add an option to configure a transition between the two image load states (low resolution and high resolution) using a blur-out effect

https://user-images.githubusercontent.com/48323313/138457062-8a9a88bd-cdef-4e09-bc14-86095306320a.mp4

DEMO - https://pro-gallery-load-transition.surge.sh/?behaviourParams_item_loadTransition=1