### PR TITLE
Prevent scroll attempt in scrollLess gallery

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -54,7 +54,6 @@ export class GalleryContainer extends React.Component {
       playingVideoIdx: -1,
       viewComponent: null,
       firstUserInteractionExecuted: false,
-      isScrollLessGallery: this.getIsScrollLessGallery(this.props.options),
       isInHover: false,
     };
 
@@ -366,7 +365,6 @@ export class GalleryContainer extends React.Component {
       options,
       container,
       structure,
-      isScrollLessGallery: this.getIsScrollLessGallery(options),
     };
     return newState;
   }
@@ -396,7 +394,7 @@ export class GalleryContainer extends React.Component {
           gotFirstScrollEvent:true,
         });
       }
-      if (this.state.isScrollLessGallery) {
+      if (this.getIsScrollLessGallery(this.state.options)) {
         return;
       }
       const scrollingElement = this._scrollingElement;
@@ -649,7 +647,7 @@ export class GalleryContainer extends React.Component {
     }
     if (eventName === GALLERY_CONSTS.events.CURRENT_ITEM_CHANGED) {
       this.setCurrentSlideshowViewIdx(eventData.idx);
-      if (this.state.isScrollLessGallery) {
+      if (this.getIsScrollLessGallery(this.state.options)) {
         this.simulateScrollToItem(this.galleryStructure.items[eventData.idx]);
       }
     }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -80,9 +80,7 @@ export class GalleryContainer extends React.Component {
   }
   initializeScrollPosition() {
     if (this.props.activeIndex > 0) {
-      if (!this.state.isScrollLessGallery) {
-        this.scrollToItem(this.props.activeIndex, false, true, 0);
-      }
+      this.scrollToItem(this.props.activeIndex, false, true, 0);
       const currentItem = this.galleryStructure.items[this.props.activeIndex];
       this.onGalleryScroll(currentItem.offset);
     }
@@ -126,8 +124,7 @@ export class GalleryContainer extends React.Component {
     }
     if (
       this.props.activeIndex !== nextProps.activeIndex &&
-      nextProps.activeIndex !== this.currentSlideshowViewIdx &&
-      !this.state.isScrollLessGallery
+      nextProps.activeIndex !== this.currentSlideshowViewIdx
     ) {
       this.scrollToItem(nextProps.activeIndex, false, true, 0);
     }
@@ -398,6 +395,9 @@ export class GalleryContainer extends React.Component {
         this.setState({
           gotFirstScrollEvent:true,
         });
+      }
+      if (this.isScrollLessGallery) {
+        return;
       }
       const scrollingElement = this._scrollingElement;
       const horizontalElement = scrollingElement.horizontal();

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -80,7 +80,9 @@ export class GalleryContainer extends React.Component {
   }
   initializeScrollPosition() {
     if (this.props.activeIndex > 0) {
-      this.scrollToItem(this.props.activeIndex, false, true, 0);
+      if (!this.state.isScrollLessGallery) {
+        this.scrollToItem(this.props.activeIndex, false, true, 0);
+      }
       const currentItem = this.galleryStructure.items[this.props.activeIndex];
       this.onGalleryScroll(currentItem.offset);
     }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -124,7 +124,8 @@ export class GalleryContainer extends React.Component {
     }
     if (
       this.props.activeIndex !== nextProps.activeIndex &&
-      nextProps.activeIndex !== this.currentSlideshowViewIdx
+      nextProps.activeIndex !== this.currentSlideshowViewIdx &&
+      !this.state.isScrollLessGallery
     ) {
       this.scrollToItem(nextProps.activeIndex, false, true, 0);
     }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -396,7 +396,7 @@ export class GalleryContainer extends React.Component {
           gotFirstScrollEvent:true,
         });
       }
-      if (this.isScrollLessGallery) {
+      if (this.state.isScrollLessGallery) {
         return;
       }
       const scrollingElement = this._scrollingElement;


### PR DESCRIPTION
The gallery tries to scroll on activeIndex change from props. in the case of slideAnimation there is no scrolling, this causes an interruption in the FADE/DECK animation which doesn't require scrolling