### PR TITLE
dont force titlePlacement in horizontal galleries

### DIFF
--- a/packages/lib/src/core/helpers/layoutHelper.js
+++ b/packages/lib/src/core/helpers/layoutHelper.js
@@ -95,8 +95,7 @@ if (
   ) {
     if (
       (!_options.isVertical || //layout orientation is horizontal
-        _options.groupSize > 1 || //groups are larger than one (items can be on top or right left of eachother)
-        (_options.scrollDirection === GALLERY_CONSTS.scrollDirection.HORIZONTAL && !GALLERY_CONSTS.isLayout('DESIGNED_PRESET')(_options))) //any horizontal layout that wasnt intentionally designed this way
+        _options.groupSize > 1) //groups are larger than one (items can be on top or right left of eachother)
     ) {
       // Dont allow titlePlacement to be above / below / left / right
       _options.titlePlacement = PLACEMENTS.SHOW_ON_HOVER;

--- a/packages/lib/src/settings/options/titlePlacement.js
+++ b/packages/lib/src/settings/options/titlePlacement.js
@@ -5,11 +5,8 @@ import { createOptions } from '../utils/utils';
 export default {
   title: 'Texts Placement',
   isRelevantDescription:
-    'Set a Vertical gallery ("Scroll Direction" as "Vertical"), set "Layout Orientation" to "Columns" and set "Max Group Size" to "1".',
-  isRelevant: (options) =>
-    (options.isVertical ||
-      options.scrollDirection === GALLERY_CONSTS.scrollDirection.HORIZONTAL) &&
-    options.groupSize === 1,
+    'Set "Layout Orientation" to "Columns" and set "Max Group Size" to "1".',
+  isRelevant: (options) => options.isVertical || options.groupSize === 1,
   type: INPUT_TYPES.MULTISELECT,
   default: GALLERY_CONSTS.placements.SHOW_ON_HOVER,
   options: createOptions('placements'),


### PR DESCRIPTION
**What** - removing check for scrollDirection in forceInfoOnHoverWhenNeeded
**Why** - the gallery can handle titlePlacement change in horizontal assuming the other conditions are met (columns,slider,is vertical, groupSize), with the exception of texts on the sides (SHOW_ON_THE_RIGHT, SHOW_ON_THE_LEFT)