### PR TITLE
import and export numberOfImagesPerCol as layoutParams_structure_numb…

### DIFF
--- a/packages/lib/src/settings/options/index.js
+++ b/packages/lib/src/settings/options/index.js
@@ -10,6 +10,7 @@ import layoutParams_gallerySpacing from './gallerySpacing';
 import isVertical from './isVertical';
 import numberOfImagesPerRow from './numberOfImagesPerRow';
 import numberOfImagesPerCol from './numberOfImagesPerCol';
+import layoutParams_structure_numberOfGridRows from './numberOfImagesPerCol';
 import galleryTextAlign from './galleryTextAlign';
 import videoPlay from './videoPlay';
 import imageHoverAnimation from './imageHoverAnimation';
@@ -113,6 +114,7 @@ export default {
   isVertical,
   numberOfImagesPerRow,
   numberOfImagesPerCol,
+  layoutParams_structure_numberOfGridRows,
   galleryTextAlign,
   videoPlay,
   imageHoverAnimation,


### PR DESCRIPTION
Note:
options map already exported from pro gallery lib,
So the only change is to export "numberOfImagesPerCol" as layoutParams structure_numberOfGridRows
(I checked the flow with the new key to see if it works)