### PR TITLE
fix jump focus galleries.

### DIFF
--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -26,12 +26,12 @@ export function onAnchorFocus({
   }
 }
 
-function isThisGalleryElementInFocus(className, id) {
+function isThisGalleryElementInFocus(className, galleryId) {
   const activeElement = window.document.activeElement;
   return (
     String(activeElement.className).includes(className) &&
     !!window.document.querySelector(
-      `#pro-gallery-${id} #${String(activeElement.id)}`
+      `#pro-gallery-${galleryId} #${String(activeElement.id)}`
     )
   );
 }

--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -10,11 +10,6 @@ function shouldChangeActiveElement() {
   return (isSiteMode() || isSEOMode()) && !utils.isMobile() && window.document;
 }
 
-function isThisGalleryElementInFocus(className) {
-  const activeElement = window.document.activeElement;
-  return String(activeElement.className).includes(className);
-}
-
 export function onAnchorFocus({
   itemContainer,
   enableExperimentalFeatures,
@@ -31,6 +26,16 @@ export function onAnchorFocus({
   }
 }
 
+function isThisGalleryElementInFocus(className, id) {
+  const activeElement = window.document.activeElement;
+  return (
+    String(activeElement.className).includes(className) &&
+    !!window.document.querySelector(
+      `#pro-gallery-${id} #${String(activeElement.id)}`
+    )
+  );
+}
+
 export function changeActiveElementIfNeeded({
   prevProps,
   currentProps,
@@ -42,10 +47,13 @@ export function changeActiveElementIfNeeded({
       window.document.activeElement.className
     ) {
       const isGalleryItemInFocus = isThisGalleryElementInFocus(
-        'gallery-item-container'
+        'gallery-item-container',
+        currentProps.galleryId
       );
-      const isShowMoreInFocus = isThisGalleryElementInFocus('show-more');
-
+      const isShowMoreInFocus = isThisGalleryElementInFocus(
+        'show-more',
+        currentProps.galleryId
+      );
       if (isGalleryItemInFocus || isShowMoreInFocus) {
         if (
           currentProps.thumbnailHighlightId !==


### PR DESCRIPTION
https://jira.wixpress.com/browse/PHOT-2494 -(its in the comments below) Autoplay in Slideshow/Slider steal the keyboard focus
expected - focus stays on the element you focused on
actual - the autoplay galleries steal the focus and move it to the center item each time