### PR TITLE
Maybe breaking - remove redundant check.

### DIFF
--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -456,8 +456,7 @@ class ItemView extends React.Component {
 
     const itemStyles = { width: innerWidth, height: innerHeight, marginTop: innerTop, marginLeft: innerLeft };
     let itemHover = null;
-    const isSlideshow = GALLERY_CONSTS.isLayout('SLIDESHOW')(options)
-    if (this.shouldHover() || isSlideshow) {
+    if (this.shouldHover()) {
       itemHover = this.getItemHover(itemStyles);
     }
 
@@ -481,7 +480,7 @@ class ItemView extends React.Component {
         }
     }
 
-    if (isSlideshow) {
+    if (GALLERY_CONSTS.isLayout('SLIDESHOW')(options)) {
       return this.getSlideshowItemInner({options, width, height, itemInner, customComponents: this.props.customComponents})
     }
 


### PR DESCRIPTION
### Why?
`futureSlideshowGallery` will replace `slideshowGallery` and will return `false` for `isSlideshow`. Therefor,  I want to get rid of as many `isSlideshow` occurences as possible. 

### What?
Since the `slideshowGallery` is already a [NEVER_SHOW](https://github.com/wix/pro-gallery/blob/c0f03e4082c77e210174963d35368b4783e8e4c0/packages/lib/src/core/presets/slideshowGallery.js#L20) then this check near the `shouldHover` is duplicated inside the [method itself](https://github.com/wix/pro-gallery/blob/c0f03e4082c77e210174963d35368b4783e8e4c0/packages/gallery/src/components/item/itemView.js#L325-L326)
First commit [green canary](https://github.com/wix-private/photography-pro-gallery/pull/1211) (4.0.15-634bbc990674a624c074b28cee5e4e92f48a53d1.0+634bbc9)