### PR TITLE
Maybe breaking - remove constant condition.

### DIFF
--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -1000,7 +1000,7 @@ class ItemView extends React.Component {
         {this.getLeftInfoElementIfNeeded()}
         <div
           style={{
-            ...(!this.props.options.isSlideshow &&
+            ...(
               getImageStyle(this.props.options)),
             ...(GALLERY_CONSTS.hasExternalRightPlacement(
               this.props.options.titlePlacement,


### PR DESCRIPTION
Why?
The `this.props.options.isSlideshow` is deprecated a long time ago and should be false all the time. This is just removing a condition that is always true

 [passing canary](https://github.com/wix-private/photography-pro-gallery/pull/1219) 4.0.15-13f1d8af1e57e583cf852724a6bc3ecc3b31f20b.0+13f1d8a