### PR TITLE
use state to track scroll and check visiblity

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -718,7 +718,6 @@ export class GalleryContainer extends React.Component {
         ...this.state.scrollPosition,
         ...eventData,
       };
-      console.log(newScrollPosition);
       this.setState({scrollPosition: newScrollPosition})
     }
   }

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -552,19 +552,14 @@ export class GalleryContainer extends React.Component {
       GALLERY_CONSTS.events.GALLERY_SCROLLED,
       { top, left }
     );
-    this.videoScrollHelper.trigger.SCROLL({
-      top,
-      left,
-    });
-    this.updateVisibility();
   }
 
-  isInViewport = () => {
-    return isGalleryInViewport(this.props.container);
-  }
 
   updateVisibility = () => {
-    const isInViewport = this.isInViewport();
+    const isInViewport = isGalleryInViewport({
+      container: this.props.container,
+      scrollTop: this.state.pgScroll
+    });
     if (this.state.isInViewport !== isInViewport) {
       this.setState({
         isInViewport,
@@ -572,9 +567,16 @@ export class GalleryContainer extends React.Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
    // in order to update when container is available
-   this.updateVisibility();
+   const { container } = this.props;
+   const { pgScroll } = this.state;
+   if (
+     container.scrollBase !== prevProps.container.scrollBase ||
+     pgScroll !== prevState.pgScroll
+     ) {
+      this.updateVisibility();
+   }
   }
 
   createDynamicStyles({ overlayBackground }, isPrerenderMode) {
@@ -703,6 +705,17 @@ export class GalleryContainer extends React.Component {
     }
     if (typeof this.props.eventsListener === 'function') {
       this.props.eventsListener(eventName, eventData, event);
+    }
+
+    if (eventName === GALLERY_CONSTS.events.GALLERY_SCROLLED) {
+      const { top, left } = eventData;
+      this.videoScrollHelper.trigger.SCROLL({
+        top,
+        left,
+      });
+      this.setState({
+        pgScroll: top || this.state.pgScroll, // incase of horizontal scroll there is no top
+      })
     }
   }
 

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -47,7 +47,7 @@ export class GalleryContainer extends React.Component {
       this.setPlayingIdxState
     );
     const initialState = {
-      pgScroll: 0,
+      scrollTop: 0,
       showMoreClickedAtLeastOnce: false,
       initialGalleryHeight: undefined,
       needToHandleShowMoreClick: false,
@@ -558,7 +558,7 @@ export class GalleryContainer extends React.Component {
   updateVisibility = () => {
     const isInViewport = isGalleryInViewport({
       container: this.props.container,
-      scrollTop: this.state.pgScroll
+      scrollTop: this.state.scrollTop
     });
     if (this.state.isInViewport !== isInViewport) {
       this.setState({
@@ -570,10 +570,10 @@ export class GalleryContainer extends React.Component {
   componentDidUpdate(prevProps, prevState) {
    // in order to update when container is available
    const { container } = this.props;
-   const { pgScroll } = this.state;
+   const { scrollTop } = this.state;
    if (
      container.scrollBase !== prevProps.container.scrollBase ||
-     pgScroll !== prevState.pgScroll
+     scrollTop !== prevState.scrollTop
      ) {
       this.updateVisibility();
    }
@@ -679,6 +679,14 @@ export class GalleryContainer extends React.Component {
     item?.offset && this.onGalleryScroll(item.offset);
   }
 
+  setScrollTop = (top) => {
+    if (top >= 0) {
+      this.setState({
+        scrollTop: top,
+      })
+    }
+    
+  }
   eventsListener(eventName, eventData, event) {
     this.videoScrollHelper.handleEvent({
       eventName,
@@ -713,9 +721,7 @@ export class GalleryContainer extends React.Component {
         top,
         left,
       });
-      this.setState({
-        pgScroll: top || this.state.pgScroll, // incase of horizontal scroll there is no top
-      })
+      this.setScrollTop(top)
     }
   }
 

--- a/packages/gallery/src/components/gallery/proGallery/galleryHelpers.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryHelpers.js
@@ -22,7 +22,6 @@ export function isGalleryInViewport({ container, scrollTop }) {
     const isTopVisible = container.scrollBase < scrollTop + window.innerHeight;
     const isBottomVisible =
       container.scrollBase + container.galleryHeight > scrollTop;
-    console.log(isBottomVisible && isTopVisible);
     return isTopVisible && isBottomVisible;
   } catch (e) {
     console.warn('Could not calculate viewport', e);

--- a/packages/gallery/src/components/gallery/proGallery/galleryHelpers.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryHelpers.js
@@ -17,33 +17,13 @@ export class Deferred {
   }
 }
 
-export function isGalleryInViewport(container) {
+export function isGalleryInViewport({ container, scrollTop }) {
   try {
-    const haveAllVariablesForViewPortCalc = !!(
-      container &&
-      Number.isInteger(container.scrollBase) &&
-      Number.isInteger(container.galleryHeight) &&
-      window &&
-      window.document &&
-      window.document.documentElement &&
-      (Number.isInteger(window.document.documentElement.scrollTop) ||
-        (window.document.scrollingElement &&
-          Number.isInteger(window.document.scrollingElement.scrollTop))) &&
-      Number.isInteger(window.document.documentElement.offsetHeight)
-    );
-    const inTopViewPort =
-      haveAllVariablesForViewPortCalc &&
-      container.scrollBase + container.galleryHeight >
-        window.document.documentElement.scrollTop;
-    const inBottomViewPort =
-      haveAllVariablesForViewPortCalc &&
-      container.scrollBase <
-        (window.document.documentElement.scrollTop ||
-          window.document.scrollingElement.scrollTop) +
-          window.document.documentElement.offsetHeight;
-    return (
-      (inTopViewPort && inBottomViewPort) || !haveAllVariablesForViewPortCalc
-    ); // if some parameters are missing (haveAllVariablesForViewPortCalc is false) we still want the used functionality to work
+    const isTopVisible = container.scrollBase < scrollTop + window.innerHeight;
+    const isBottomVisible =
+      container.scrollBase + container.galleryHeight > scrollTop;
+    console.log(isBottomVisible && isTopVisible);
+    return isTopVisible && isBottomVisible;
   } catch (e) {
     console.warn('Could not calculate viewport', e);
     return true;

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -9,7 +9,6 @@ import {
 } from 'pro-gallery-lib';
 import GroupView from '../../group/groupView.js';
 import GalleryDebugMessage from './galleryDebugMessage.js';
-import { isGalleryInViewport } from './galleryHelpers.js';
 import PlayIcon from '../../svgs/components/play';
 import PauseIcon from '../../svgs/components/pause';
 import TextItem from '../../item/textItem.js';
@@ -458,7 +457,7 @@ class SlideshowView extends React.Component {
   autoScrollToNextItem = () => {
     if (
       !isEditMode() &&
-      (isGalleryInViewport(this.props.container) || isPreviewMode())
+      (this.props.isInViewport || isPreviewMode())
     ) {
       const { options } = this.props;
       const direction = options.isRTL ? -1 : 1;


### PR DESCRIPTION
**changes related scroll event:**

1. rewrite `isGalleryInViewport` relies on document API and values which is relevant only to galleries on the page (which creates a bug in lightboxes/modals)  instead use the value from the scroll event
2. keep track of the scroll top state and trigger visibility check on `componentDidUpdate` only if it was updated
3. scroll actions pass through eventsListener `GALLERY_SCROLLED` event