### PR TITLE
use overflow only in prerender mode

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -870,7 +870,7 @@ class SlideshowView extends React.Component {
       const columnStyle = {
         width: this.props.isPrerenderMode ? '100%' : column.width,
         height: this.getDimensions().height,
-        overflowY: 'visible',
+        overflowY: this.props.isPrerenderMode ? 'visible' : 'hidden',
       };
       return (
         <div


### PR DESCRIPTION
Apply overflow only in prerender mode to prevent scrolling withing the gallery