### PR TITLE
process grid style for masonry

### DIFF
--- a/packages/lib/src/core/helpers/layoutHelper.js
+++ b/packages/lib/src/core/helpers/layoutHelper.js
@@ -55,6 +55,13 @@ export const processNumberOfImagesPerRow = (options) => {
   return res;
 }
 
+export const processGridStyle = (options) => {
+  let res = {...options};
+  res.gridStyle =
+    res.isVertical ? options.gridStyle : GALLERY_CONSTS.gridStyle.FIT_TO_SCREEN;
+  return res;
+}
+
 export const processNumberOfImagesPerCol = (options) => {
   //This will be used in the grid preset
   let res = {...options}

--- a/packages/lib/src/core/presets/masonryGallery.js
+++ b/packages/lib/src/core/presets/masonryGallery.js
@@ -3,6 +3,7 @@ import SCROLL_DIRECTION from '../../common/constants/scrollDirection';
 import {
   calcTargetItemSize,
   processNumberOfImagesPerRow,
+  processGridStyle,
 } from '../helpers/layoutHelper';
 import { featureManager } from '../helpers/versionsHelper';
 
@@ -30,5 +31,6 @@ export const createOptions = (options) => {
   if (featureManager.supports.fixedColumnsInMasonry) {
     res = processNumberOfImagesPerRow(res);
   }
+  res = processGridStyle(res);
   return res;
 };


### PR DESCRIPTION
gridStyle needs to be processed in masonry when switching to horizontal layout for the isRelevant to work properly