### PR TITLE
bug scroll ios

### DIFF
--- a/packages/gallery/src/components/styles/gallery.scss
+++ b/packages/gallery/src/components/styles/gallery.scss
@@ -732,6 +732,8 @@ div.pro-gallery {
   left: var(--group-left);
   width: var(--group-width);
   right: var(--group-right);
+  height: '1px';
+  pointer-events: none;
 }
 
 $group-view: '[data-hook="group-view"]';

--- a/packages/gallery/src/components/styles/gallery.scss
+++ b/packages/gallery/src/components/styles/gallery.scss
@@ -732,7 +732,7 @@ div.pro-gallery {
   left: var(--group-left);
   width: var(--group-width);
   right: var(--group-right);
-  height: '1px';
+  height: 1px;
   pointer-events: none;
 }
 


### PR DESCRIPTION
fixing https://jira.wixpress.com/browse/PHOT-3025
explanation: in ios the pseudo element didnt work without height- so in ios the scroll didnt work well