### PR TITLE
fix: deploy to surge

### DIFF
--- a/scripts/deployToSurge.js
+++ b/scripts/deployToSurge.js
@@ -37,7 +37,12 @@ const generateSubdomains = subdomain => {
       console.log(chalk.magenta(`Add subdomain: ${subdomains[subdomains.length - 1]}`));
   } else {
     //push with branch suffix
-    subdomains.push(subdomain + `-${formatBranchName(GITHUB_HEAD_REF)}`);
+    const branchName = formatBranchName(GITHUB_HEAD_REF);
+    if (branchName) {
+        subdomains.push(`${subdomain}-${branchName}`);
+    } else {
+        subdomains.push(subdomain);
+    }
     console.log(chalk.magenta(`Add subdomain: ${subdomains[subdomains.length - 1]}`));
   }
 


### PR DESCRIPTION
For now the latest playground is publishing to:
https://pro-gallery-.surge.sh/ (`v4.1.1`)

https://pro-gallery.surge.sh/ has `v3.1.38` as latest version published:
<img width="433" alt="image" src="https://user-images.githubusercontent.com/439289/172608554-73ce3548-b6ce-4a76-90bd-9583512bdd3c.png">

