### PR TITLE
Rendering two infos regardless of titlePlacement

### DIFF
--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -500,7 +500,7 @@ class ItemView extends React.Component {
   }
 
   shouldRenderNewInfoType(infoType) {
-    if (!this.props.infoElementsOptions) {
+    if (!this.props.options.infoElementsOptions) {
       return false;
     }
     return Object.values(

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -322,6 +322,9 @@ class ItemView extends React.Component {
     } = options;
     const { NEVER_SHOW, APPEARS } = GALLERY_CONSTS.infoBehaviourOnHover;
     const { NO_EFFECT } = GALLERY_CONSTS.overlayAnimations;
+    if (this.shouldRenderNewInternalInfoElement()) {
+      return true;
+    }
 
     if (hoveringBehaviour === NEVER_SHOW) {
       return false;
@@ -496,8 +499,22 @@ class ItemView extends React.Component {
     return itemInner;
   }
 
+  shouldRenderNewInfoType(infoType) {
+    return Object.values(
+      this.props.options.infoElementsOptions[infoType].enabled
+    ).includes(true);
+  }
+
+  shouldRenderNewExternalInfoElement() {
+    return this.shouldRenderNewInfoType('external');
+  }
+  shouldRenderNewInternalInfoElement() {
+    return this.shouldRenderNewInfoType('internal');
+  }
+
   getRightInfoElementIfNeeded() {
     if (
+      this.shouldRenderNewExternalInfoElement() ||
       GALLERY_CONSTS.hasExternalRightPlacement(
         this.props.options.titlePlacement,
         this.props.idx
@@ -514,6 +531,7 @@ class ItemView extends React.Component {
 
   getLeftInfoElementIfNeeded() {
     if (
+      this.shouldRenderNewExternalInfoElement() ||
       GALLERY_CONSTS.hasExternalLeftPlacement(
         this.props.options.titlePlacement,
         this.props.idx
@@ -530,6 +548,7 @@ class ItemView extends React.Component {
 
   getBottomInfoElementIfNeeded() {
     if (
+      this.shouldRenderNewExternalInfoElement() ||
       GALLERY_CONSTS.hasExternalBelowPlacement(
         this.props.options.titlePlacement,
         this.props.idx
@@ -546,6 +565,7 @@ class ItemView extends React.Component {
 
   getTopInfoElementIfNeeded() {
     if (
+      this.shouldRenderNewExternalInfoElement() ||
       GALLERY_CONSTS.hasExternalAbovePlacement(
         this.props.options.titlePlacement,
         this.props.idx
@@ -614,6 +634,7 @@ class ItemView extends React.Component {
 
   simulateHover() {
     return (
+      this.shouldRenderNewInternalInfoElement() ||
       this.state.isCurrentHover ||
       this.props.options.alwaysShowHover === true ||
       (isEditMode() && this.props.options.previewHover)
@@ -936,8 +957,9 @@ class ItemView extends React.Component {
     this.hasRequiredMediaUrl = url || type === 'text';
     //if titlePlacement !== SHOW_ON_HOVER and !this.hasRequiredMediaUrl, we will NOT render the itemWrapper (but will render the info element with the whole size of the item)
     const isItemWrapperEmpty =
-      options.titlePlacement !== GALLERY_CONSTS.placements.SHOW_ON_HOVER &&
-      !this.hasRequiredMediaUrl;
+      this.shouldRenderNewInternalInfoElement() === false ||
+      (options.titlePlacement !== GALLERY_CONSTS.placements.SHOW_ON_HOVER &&
+        !this.hasRequiredMediaUrl);
     const innerDiv = (
       <div
         className={this.getItemContainerClass()}

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -500,6 +500,9 @@ class ItemView extends React.Component {
   }
 
   shouldRenderNewInfoType(infoType) {
+    if (!this.props.infoElementsOptions) {
+      return false;
+    }
     return Object.values(
       this.props.options.infoElementsOptions[infoType].enabled
     ).includes(true);

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -960,7 +960,7 @@ class ItemView extends React.Component {
     this.hasRequiredMediaUrl = url || type === 'text';
     //if titlePlacement !== SHOW_ON_HOVER and !this.hasRequiredMediaUrl, we will NOT render the itemWrapper (but will render the info element with the whole size of the item)
     const isItemWrapperEmpty =
-      this.shouldRenderNewInternalInfoElement() === false ||
+      this.shouldRenderNewInternalInfoElement() ||
       (options.titlePlacement !== GALLERY_CONSTS.placements.SHOW_ON_HOVER &&
         !this.hasRequiredMediaUrl);
     const innerDiv = (

--- a/packages/gallery/tests/e2e/integration/rce.e2e.spec.js
+++ b/packages/gallery/tests/e2e/integration/rce.e2e.spec.js
@@ -15,7 +15,7 @@ describe('RCE Integration test', () => {
   afterAll(async () => {
     await driver.closePage();
   });
-  it.skip('should match screenshot with default RCE styles', async () => {
+  it('should match screenshot with default RCE styles', async () => {
     await driver.navigate({
       layoutParams: {
         gallerySpacing: 0,

--- a/packages/gallery/tests/e2e/integration/rce.e2e.spec.js
+++ b/packages/gallery/tests/e2e/integration/rce.e2e.spec.js
@@ -15,7 +15,7 @@ describe('RCE Integration test', () => {
   afterAll(async () => {
     await driver.closePage();
   });
-  it('should match screenshot with default RCE styles', async () => {
+  it.skip('should match screenshot with default RCE styles', async () => {
     await driver.navigate({
       layoutParams: {
         gallerySpacing: 0,


### PR DESCRIPTION
### Why?

1. I need to support 2 infos rendered at the same time in the new info elements
2. 

### What?

1. Defensively checking if `infoElementsOptions` (new SP available only on new info panel) is availbale. Flow is the same if it doesn't exist
2. Checking if there is at least one info enabled in external or internal info
3. Forcing simulate hover if the above condition is met