### PR TITLE
Do not try to infer link text from link

### DIFF
--- a/packages/layouts/src/classes/galleryItem.js
+++ b/packages/layouts/src/classes/galleryItem.js
@@ -829,7 +829,7 @@ class GalleryItem {
           return 'Go to Link';
         }
       case 'web':
-        return this.linkTitleFromUrl || this.linkUrl;
+        return this.linkUrl;
       case 'page':
         return this.linkTitle;
       default:
@@ -912,13 +912,6 @@ class GalleryItem {
 
   get isWixUrl() {
     return this.linkUrl && this.linkUrl.indexOf('wix') === 0;
-  }
-
-  get linkTitleFromUrl() {
-    const regex = /[^/]*\.\w+$/g;
-    const regexRes = regex.exec(this.linkUrl);
-    const match = regexRes && regexRes[0];
-    return match && match.split('.')[0];
   }
 
   get unprotectedLinkOpenType() {


### PR DESCRIPTION
**What**
Do not try to extract a title from the provided link when link text is not given and just use link value as text

**Why**
Trying to cover the different link formats and extract a title should not be our responsibility and can be done by the user using the link `text` field
current code produces the following text for links:
`https://www.google.com => www`
`https://google.com => google`
