### PR TITLE
Expand Mode Preview Bug

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/navigationArrows.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationArrows.js
@@ -299,5 +299,5 @@ export function ArrowsContainer({
       </div>
     );
   }
-  return <>{children}</>;
+  return <div>{children}</div>;
 }

--- a/packages/gallery/src/components/gallery/proGallery/navigationArrows.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationArrows.js
@@ -299,5 +299,9 @@ export function ArrowsContainer({
       </div>
     );
   }
-  return <div>{children}</div>;
+  return React.Fragment ? (
+    <React.Fragment>{children}</React.Fragment>
+  ) : (
+    <div>{children}</div>
+  );
 }


### PR DESCRIPTION
https://jira.wixpress.com/browse/PHOT-3295

React.Fragment (<></>) is not accepted in older versions. So if it's an older version we return a div, otherwise - React.Fragment.