### PR TITLE
fix isRelevant for taregtItemSize

### DIFF
--- a/packages/lib/src/settings/options/layoutParams_targetItemSize_value.js
+++ b/packages/lib/src/settings/options/layoutParams_targetItemSize_value.js
@@ -1,10 +1,16 @@
+import { default as GALLERY_CONSTS } from '../../common/constants';
+import optionsMap from '../../core/helpers/optionsMap';
+
 export default {
   title: 'Item Size (smart)',
   description: `Set the item size between 1 to 100 units. The real size will be determined by the layout.`,
-  isRelevant: () => {
-    return true;
+  isRelevant: (options) => {
+    return (
+      options[optionsMap.layoutParams.structure.scrollDirection] ===
+      GALLERY_CONSTS[optionsMap.layoutParams.structure.scrollDirection].VERTICAL
+    );
   },
   isRelevantDescription:
-    'Set a Horizontal gallery ("Scroll Direction" as "Horizontal") and set Responsive Type to Fit to screen',
+    'Set a VERTICAL gallery ("Scroll Direction" as "Vertical") and set Responsive Type to Fit to screen',
   default: 30,
 };


### PR DESCRIPTION
**Checking for layout direction in `targetItemSize` isRelevant**
While changing the targetItemSize does have some effect in horizontal galleries, the results don't really make sense. I'd say its more broken in horizontal galleries. I think we should restrict it to vertical galleries for now.