### PR TITLE
Window wrapper mock

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -7,6 +7,7 @@ import {
   isSEOMode,
   isPreviewMode,
   isSiteMode,
+  windowWrapper,
 } from 'pro-gallery-lib';
 import { ItemsHelper } from 'pro-layouts';
 import GalleryView from './galleryView';
@@ -130,6 +131,7 @@ export class GalleryContainer extends React.Component {
   }
 
   componentDidMount() {
+    windowWrapper.isGalleryMounted = true;
     const { body, documentElement: html } = document;
     const viewportHeight = window.innerHeight;
     const height = Math.max(
@@ -301,7 +303,6 @@ export class GalleryContainer extends React.Component {
     const scrollY = window.scrollY;
     const { galleryHeight, scrollBase, galleryWidth } = container;
     if (
-      utils.isSSR() ||
       isSEOMode() ||
       isEditMode() ||
       gotFirstScrollEvent ||

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -131,7 +131,7 @@ export class GalleryContainer extends React.Component {
   }
 
   componentDidMount() {
-    windowWrapper.isGalleryMounted = true;
+    windowWrapper.stopUsingMock();
     const { body, documentElement: html } = document;
     const viewportHeight = window.innerHeight;
     const height = Math.max(

--- a/packages/lib/src/common/window/window.mock.js
+++ b/packages/lib/src/common/window/window.mock.js
@@ -50,6 +50,10 @@ export const scrollMock = {
   scrollTop: 0,
   scrollY: 0,
 };
+const windowHydrateMock = {
+  ...dimsMock,
+  ...scrollMock,
+};
 const windowMock = {
   isMock: true,
   isSSR: true,
@@ -71,10 +75,12 @@ const windowMock = {
   getComputedStyle: noop,
   localStorage: {},
   frames: [],
-  ...dimsMock,
-  ...scrollMock,
+  ...windowHydrateMock,
 };
 
+export const hydrateMockMap = new Map(
+  Object.keys(windowHydrateMock).map((key) => [key, windowHydrateMock[key]])
+);
 windowMock.parent = windowMock;
 
 export default windowMock;

--- a/packages/lib/src/common/window/window.mock.js
+++ b/packages/lib/src/common/window/window.mock.js
@@ -2,7 +2,7 @@ const noop = () => ({});
 const width = 2560;
 const height = 1440;
 
-const dims = {
+export const dimsMock = {
   y: 0,
   x: 0,
   width,
@@ -16,8 +16,8 @@ const dims = {
 };
 
 const elem = {
-  ...dims,
-  getBoundingClientRect: () => dims,
+  ...dimsMock,
+  getBoundingClientRect: () => dimsMock,
 };
 
 const documentMock = {
@@ -30,8 +30,8 @@ const documentMock = {
   querySelector: () => [elem],
   documentElement: elem,
   activeElement: elem,
-  style: dims,
-  ...dims,
+  style: dimsMock,
+  ...dimsMock,
 };
 
 documentMock.body = documentMock;
@@ -46,18 +46,20 @@ const locationMock = {
   search: '',
   hash: '',
 };
-
+export const scrollMock = {
+  scrollTop: 0,
+  scrollY: 0,
+};
 const windowMock = {
   isMock: true,
   isSSR: true,
   orientation: 0,
   devicePixelRatio: 1,
-  scrollTop: 0,
   addEventListener: noop,
   removeEventListener: noop,
   createEvent: noop,
   CustomEvent: noop,
-  screen: dims,
+  screen: dimsMock,
   open: noop,
   petri: {},
   search: {},
@@ -69,7 +71,8 @@ const windowMock = {
   getComputedStyle: noop,
   localStorage: {},
   frames: [],
-  ...dims,
+  ...dimsMock,
+  ...scrollMock,
 };
 
 windowMock.parent = windowMock;

--- a/packages/lib/src/common/window/windowWrapper.js
+++ b/packages/lib/src/common/window/windowWrapper.js
@@ -1,8 +1,15 @@
-import WindowMock from './window.mock';
+import WindowMock, { dimsMock, scrollMock } from './window.mock';
 
 class WindowWrapper {
   constructor() {
-    this.reset();
+    this.initProxyWindow = this.initProxyWindow.bind(this);
+    if (this.windowIsAvailable()) {
+      // this will wrap the real window with partial mock for the dimensions
+      // once the gallery is mounted we will switch from the mocked properties to the real values
+      this.initProxyWindow();
+    } else {
+      this.initMockWindow();
+    }
   }
 
   windowIsAvailable() {
@@ -13,12 +20,42 @@ class WindowWrapper {
     }
   }
 
-  reset() {
-    this.isMock = !this.windowIsAvailable();
-    this.window = this.isMock ? WindowMock : window;
-    if (this.isMock) {
-      this.window.mockInstanceId = Math.floor(Math.random() * 100000);
-    }
+  initProxyWindow() {
+    const handler = {
+      get: function (target, property) {
+        let targetObj = target[property];
+        const dimsAndScrollMock = {
+          ...dimsMock,
+          ...scrollMock,
+        };
+        if (
+          Object.keys(dimsAndScrollMock).includes(property) &&
+          !this.isGalleryMounted
+        ) {
+          return dimsAndScrollMock[property];
+        } else if (typeof targetObj == 'function') {
+          return (...args) => target[property].apply(target, args);
+        } else {
+          return targetObj;
+        }
+      }.bind(this),
+    };
+    // eslint-disable-next-line no-undef
+    this.window = new Proxy(window, handler);
+  }
+  initMockWindow() {
+    this.window = WindowMock;
+    this.window.mockInstanceId = Math.floor(Math.random() * 100000);
+  }
+  initFinalWindow() {
+    this.window = window;
+  }
+
+  get isGalleryMounted() {
+    return this._isGalleryMounted;
+  }
+  set isGalleryMounted(isGalleryMounted) {
+    this._isGalleryMounted = isGalleryMounted;
   }
 }
 

--- a/packages/lib/src/common/window/windowWrapper.js
+++ b/packages/lib/src/common/window/windowWrapper.js
@@ -2,6 +2,7 @@ import WindowMock, { dimsMock, scrollMock } from './window.mock';
 
 class WindowWrapper {
   constructor() {
+    this.shouldUseMock = true;
     this.initProxyWindow = this.initProxyWindow.bind(this);
     if (this.windowIsAvailable()) {
       // this will wrap the real window with partial mock for the dimensions
@@ -30,7 +31,7 @@ class WindowWrapper {
         };
         if (
           Object.keys(dimsAndScrollMock).includes(property) &&
-          !this.isGalleryMounted
+          this.shouldUseMock
         ) {
           return dimsAndScrollMock[property];
         } else if (typeof targetObj == 'function') {
@@ -50,12 +51,14 @@ class WindowWrapper {
   initFinalWindow() {
     this.window = window;
   }
-
-  get isGalleryMounted() {
-    return this._isGalleryMounted;
+  stopUsingMock() {
+    this.shouldUseMock = false;
   }
-  set isGalleryMounted(isGalleryMounted) {
-    this._isGalleryMounted = isGalleryMounted;
+  get shouldUseMock() {
+    return this._shouldUseMock;
+  }
+  set shouldUseMock(shouldUseMock) {
+    this._shouldUseMock = shouldUseMock;
   }
 }
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -30,7 +30,10 @@ export { NEW_PRESETS } from './core/presets/presets';
 export { getLayoutName } from './core/presets/presets';
 export { isInPreset } from './core/presets/presets';
 
-export { default as window } from './common/window/windowWrapper';
+export {
+  default as window,
+  windowWrapper,
+} from './common/window/windowWrapper';
 export { default as utils } from './common/utils';
 
 export { viewModeWrapper } from './common/window/viewModeWrapper';


### PR DESCRIPTION
**What**
we want to use a partial window mock at the first client render
**Why**
we want the first render to use the mock values, same values used in the SSR response to prevent hydration issues

NOTE: the mock needed to be partial because we register to the window events listener when some of our components are mounted, the mocked properties on the client are dimensions and scroll
