### PR TITLE
[PHOT-3807] - calculate which visibleItems to present from the gallery scroll container instead of window top. 

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -276,7 +276,7 @@ export class GalleryContainer extends React.Component {
 
   getVisibleItems(items, container, isPrerenderMode) {
     const { gotFirstScrollEvent } = this.state;
-    const scrollY = window.scrollY;
+    const scrollY = this.state?.scrollPosition?.top || 0;
     const { galleryHeight, scrollBase, galleryWidth } = container;
     if (
       isPrerenderMode || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -284,6 +284,7 @@ export class GalleryContainer extends React.Component {
       isEditMode() ||
       gotFirstScrollEvent ||
       scrollY > 0 ||
+      isPreviewMode() ||
       this.props.activeIndex > 0
     ) {
       return items;


### PR DESCRIPTION
Fix - https://jira.wixpress.com/browse/PHOT-3807;
change getVisibleItems to get all images on preview (in initial load). 
