### PR TITLE
change shrink item animation to be on the image container and not on the image content

### DIFF
--- a/packages/gallery/src/components/styles/_hoverEffects.scss
+++ b/packages/gallery/src/components/styles/_hoverEffects.scss
@@ -85,22 +85,14 @@ div.pro-gallery {
 
     &.shrink-on-hover:not(.hide-hover) {
       transition: background-color .4s ease !important;
-
-      .gallery-item-content,
-      .gallery-item-hover:not(.hide-hover) {
-        transition: transform .4s ease !important;
-      }
+      transition: transform .4s ease !important;
 
       &.simulate-hover,
       &:hover {
-        background-color: transparent !important;
+        transform: scale(0.985);
 
-        .gallery-item-content {
-          transform: scale(0.985);
-        }
-
-        .gallery-item-hover:not(.hide-hover) {
-          transform: scale(0.987);
+        div {
+          transform: none !important;
         }
       }
     }


### PR DESCRIPTION
fix - https://wix.monday.com/boards/4776391986/pulses/5238748140?filter=XQAAAAK6AAAAAAAAAABBqQqHk62Wwa8yt9cbbXI48HpL2ei1XixEiNVOhiWmf4IrTn4lrcVxz0d8EzlqDpxL1dc7i9JjI1nNW0HEFgqaXhsDsHWTHjMEE6-qlUKWgWTaunFWUdBXUlnD6ksBNUF-ix8iV3_U-Feu4Xakffa5TWjTljysumsFSTUwEWM70MyKZaOO_hr7RKIeSDv_FebgsiEliuxt-ZRFyK4wE___kOAAAA

before 
![ezgif-1-97ec66ac87](https://github.com/wix-incubator/pro-gallery/assets/15213628/2a663504-1078-44f8-9457-745fb9522aad)

after
![ezgif-1-8dcc330e70](https://github.com/wix-incubator/pro-gallery/assets/15213628/3abe4b12-ab02-4f76-8c81-1054aebec05c)
