### PR TITLE
fix scroll to first video on autoplay

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryScrollIndicator.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryScrollIndicator.js
@@ -59,7 +59,7 @@ export default class ScrollIndicator extends React.Component {
     this.onHorizontalScroll = (e) => {
       this.props.setGotFirstScrollIfNeeded();
       const target = e.currentTarget || e.target || e;
-      let left = target && (target.scrollX || target.scrollLeft || target.x);
+      let left = target && (target.scrollX || target.scrollLeft !== undefined ? target.scrollLeft : target.x);
       if (this.props.isRTL) {
         left = Math.abs(left); //this.props.totalWidth - left;
       }

--- a/packages/gallery/src/components/gallery/proGallery/galleryScrollIndicator.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryScrollIndicator.js
@@ -59,7 +59,7 @@ export default class ScrollIndicator extends React.Component {
     this.onHorizontalScroll = (e) => {
       this.props.setGotFirstScrollIfNeeded();
       const target = e.currentTarget || e.target || e;
-      let left = target && (target.scrollX || target.scrollLeft !== undefined ? target.scrollLeft : target.x);
+      let left = target && (target.scrollX ?? target.scrollLeft ?? target.x);
       if (this.props.isRTL) {
         left = Math.abs(left); //this.props.totalWidth - left;
       }


### PR DESCRIPTION
This fix is for desktop and mobile. 
left was undefined when target.scrollLeft = 0 and target.x = undefined, so it didn't triggered the scroll.