### PR TITLE
[SEO] add alt to preload images for SEO crawlers

### DIFF
--- a/packages/gallery/src/components/item/imageItem.js
+++ b/packages/gallery/src/components/item/imageItem.js
@@ -119,6 +119,7 @@ class ImageItem extends React.Component {
 
     const image = () => {
       const imagesComponents = [];
+      const altText = typeof alt === 'string' ? alt : 'untitled image';
       const blockDownloadStyles =
         utils.isMobile() && this.props.options[optionsMap.behaviourParams.gallery.blockContextMenu]
           ? {
@@ -146,7 +147,7 @@ class ImageItem extends React.Component {
           case GALLERY_CONSTS[optionsMap.behaviourParams.item.content.loader].BLUR:
             preload = (
               <ImageRenderer
-                alt=""
+                alt={altText}
                 key={'image_preload_blur-' + id}
                 src={createUrl(GALLERY_CONSTS.urlSizes.RESIZED, GALLERY_CONSTS.urlTypes.LOW_RES)}
                 style={{
@@ -162,7 +163,7 @@ class ImageItem extends React.Component {
           case GALLERY_CONSTS[optionsMap.behaviourParams.item.content.loader].MAIN_COLOR:
             preload = (
               <ImageRenderer
-                alt=""
+                alt={altText}
                 key={'image_preload_main_color-' + id}
                 src={createUrl(GALLERY_CONSTS.urlSizes.PIXEL, GALLERY_CONSTS.urlTypes.HIGH_RES)}
                 style={{
@@ -195,7 +196,7 @@ class ImageItem extends React.Component {
           data-hook="gallery-item-image-img"
           data-idx={idx}
           src={src}
-          alt={typeof alt === 'string' ? alt : 'untitled image'}
+          alt={altText}
           tabIndex="0"
           onLoad={this.handleHighResImageLoad}
           loading={this.props.isPrerenderMode ? 'lazy' : 'eager'}


### PR DESCRIPTION
Website crawlers (like screamingFrog) reads the first alt text and treats it as anchor text. the placeholder image had an empty alt text -> anchor text was empty. 

Best description for the problem: https://docs.google.com/document/d/1h1uKcAMsPnQ1_esjGbMUBq-NmYhwyMs6Mby7BzsD06E/edit?pli=1#heading=h.h2h41eg0msxb 

We need each link to have alt **or** anchor text, here is the result: (Yana from SEO approved it)
<img width="709" alt="Screenshot 2024-03-05 at 19 21 40" src="https://github.com/wix-incubator/pro-gallery/assets/121542318/4e8dad4e-e0b4-4059-89f6-041200402c9e">
