### PR TITLE
[A11y] - Switching image using the Enter key

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -96,6 +96,11 @@ class NavigationPanel extends React.Component {
                 style={itemStyle}
                 onClick={() => this.scrollToThumbnail(idx)}
                 tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    this.scrollToThumbnail(idx);
+                  }
+                }}
               >
                 {thumbnailItem.type === 'video' &&
                   options[optionsMap.behaviourParams.item.video.enableThumbnailsPlayButton] && (


### PR DESCRIPTION
Add the ability to switch the displayed image in the gallery by pressing the Enter key on one of the thumbnails.