### PR TITLE
Replace proxy wrapper

### DIFF
--- a/packages/lib/src/common/window/windowWrapper.js
+++ b/packages/lib/src/common/window/windowWrapper.js
@@ -3,11 +3,11 @@ import WindowMock, { hydrateMockMap } from './window.mock';
 class WindowWrapper {
   constructor() {
     this.shouldUseMock = true;
-    this.initProxyWindow = this.initProxyWindow.bind(this);
+    this.initPartialWindoMock = this.initPartialWindoMock.bind(this);
     if (this.windowIsAvailable()) {
       // this will wrap the real window with partial mock for the dimensions
       // once the gallery is mounted we will switch from the mocked properties to the real values
-      this.initProxyWindow();
+      this.initPartialWindoMock();
     } else {
       this.initMockWindow();
     }
@@ -21,31 +21,19 @@ class WindowWrapper {
     }
   }
 
-  initProxyWindow() {
-    const customWindowPropsSet = new Set();
-    const handler = {
-      // here the proxy target is the global window object
-      get: function (target, property) {
-        if (hydrateMockMap.has(property) && this.shouldUseMock) {
-          return hydrateMockMap.get(property);
-        }
-        if (
-          typeof target[property] === 'function' &&
-          !customWindowPropsSet.has(property)
-        ) {
-          return target[property].bind(target);
-        }
-        return target[property];
-      }.bind(this),
-      // here we push to the custom props Set to know later if we want to bind the prop
-      // reflect just assigns the proprty and returns boolean if the assign was successfull
-      set: function (target, property, value) {
-        customWindowPropsSet.add(property);
-        return Reflect.set(target, property, value);
-      },
-    };
-    // eslint-disable-next-line no-undef
-    this.window = new Proxy(window, handler);
+  initPartialWindoMock() {
+    hydrateMockMap.forEach((value, key) => {
+      const windowPropValue = window[key];
+      Object.defineProperty(window, key, {
+        get: () => {
+          if (this.shouldUseMock) {
+            return hydrateMockMap.get(key);
+          }
+          return windowPropValue;
+        },
+      });
+    });
+    this.window = window;
   }
   initMockWindow() {
     this.window = WindowMock;


### PR DESCRIPTION
Replaced `Proxy` with `Object.defineProperty` to watch only selected properties
**Why?**
- Proxy handles all properties getters on the window which force us to manage ourself the values returned from the window and account for many type of values like components (eg: video player) and native functions that need to be binded correctly.
- Proxy causes issue when functions are set to be read-only and non-configurable since we need to bind the functions which returns a new function (once a property is set to be read-only and non-configurable the Proxy must return the exact value)

