### PR TITLE
fix invalid ARIA role attribute

### DIFF
--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -967,7 +967,7 @@ class ItemView extends React.Component {
         data-hash={hash}
         data-id={photoId}
         data-idx={idx}
-        role={this.getItemAriaRole()}
+        {...(this.getItemAriaRole() && { role: this.getItemAriaRole() })}
         data-hook="item-container"
         key={'item-container-' + id}
         style={this.getItemContainerStyles()}

--- a/packages/gallery/tests/styleParams/behaviourParams_item_clickAction.spec.js
+++ b/packages/gallery/tests/styleParams/behaviourParams_item_clickAction.spec.js
@@ -40,7 +40,7 @@ describe('options - behaviourParams_item_clickAction', () => {
       expect(item.props().role).to.eq('button');
       driver.detach.proGallery();
     });
-    it('expect "role" to be "" when "behaviourParams_item_clickAction" is "nothing"', async () => {
+    it('expect no "role" attribute when "behaviourParams_item_clickAction" is "nothing"', async () => {
       initialProps.options = Object.assign(initialProps.options, {
         [optionsMap.behaviourParams.item.clickAction]:
           GALLERY_CONSTS[optionsMap.behaviourParams.item.clickAction].NOTHING,
@@ -48,7 +48,7 @@ describe('options - behaviourParams_item_clickAction', () => {
       driver.mount.proGallery(initialProps);
       await driver.update();
       const item = driver.find.hook('item-container').at(3);
-      expect(item.props().role).to.eq('');
+      expect(item.props()).to.not.have.property('role');
       driver.detach.proGallery();
     });
   });


### PR DESCRIPTION
Ensure the ARIA role attribute (on item-container) is assigned a valid value and is never null.