### PR TITLE
Fix 'global' is undefined exception in browser env

### DIFF
--- a/packages/lib/src/common/utils/index.js
+++ b/packages/lib/src/common/utils/index.js
@@ -324,7 +324,7 @@ class Utils {
 
   // TODO : Replace with isPrerender mode
   isSSR() {
-    return typeof global?.window === 'undefined';
+    return typeof global !== 'undefined' && typeof global?.window === 'undefined';
   }
 
   isOOI() {


### PR DESCRIPTION
When trying to use pro-gallery in browser app in non-wix environment the library load fails with 'global is undefined' exception as its not defined in general case.