### PR TITLE
change invalid activeIndex when filtering items

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1168,6 +1168,18 @@ class SlideshowView extends React.Component {
         this.startAutoSlideshowIfNeeded(props.options);
       });
     }
+    if (this.state.activeIndex > props.items.length - 1) {
+      utils.setStateAndLog(
+        this,
+        'Next Item',
+        {
+          activeIndex: 0,
+        },
+        () => {
+          this.onCurrentItemChanged();
+        }
+      );
+    }
     if (this.props.activeIndex !== props.activeIndex) {
       utils.setStateAndLog(
         this,


### PR DESCRIPTION
Set the active index to 0 when the number of items in the gallery is smaller than the current active index in order to prevent the display of an item that does not exist (relevant for filtering out gallery items).