### PR TITLE
get correct galleryStructure to calculate gallery width

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1192,7 +1192,11 @@ class SlideshowView extends React.Component {
         }
       );
     }
-    if (this.props.totalItemsCount !== props.totalItemsCount) {
+    if (
+      this.props.totalItemsCount !== props.totalItemsCount ||
+      this.props.container.galleryHeight !== props.container.galleryHeight ||
+      this.props.container.galleryWidth !== props.container.galleryWidth
+    ) {
       this.removeArrowsIfNeeded(props);
     }
     if (isEditMode() || isPreviewMode()) {

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -77,8 +77,8 @@ class SlideshowView extends React.Component {
     return this.state.activeIndex === 0;
   }
 
-  isScrollStart() {
-    const { slideAnimation } = this.props.options;
+  isScrollStart(props = this.props) {
+    const { slideAnimation } = props.options;
 
     if (
       slideAnimation !== GALLERY_CONSTS.slideAnimations.SCROLL ||
@@ -90,7 +90,7 @@ class SlideshowView extends React.Component {
   }
 
   isScrollEnd(props = this.props) {
-    const { slideshowLoop, slideAnimation } = this.props.options;
+    const { slideshowLoop, slideAnimation } = props.options;
     if (
       slideshowLoop ||
       slideAnimation === GALLERY_CONSTS.slideAnimations.FADE ||
@@ -134,10 +134,10 @@ class SlideshowView extends React.Component {
     return !this.props.options.slideshowLoop && this.isScrollEnd();
   }
 
-  isLastItem() {
+  isLastItem(props = this.props) {
     return (
-      !this.props.options.slideshowLoop &&
-      this.state.activeIndex >= this.props.totalItemsCount - 1
+      !props.options.slideshowLoop &&
+      this.state.activeIndex >= props.totalItemsCount - 1
     );
   }
 
@@ -1218,10 +1218,10 @@ class SlideshowView extends React.Component {
     const { isRTL } = props.options;
     const { hideLeftArrow, hideRightArrow } = this.state;
 
-    const isScrollStart = this.isScrollStart();
+    const isScrollStart = this.isScrollStart(props);
     const isFirstItem = this.isFirstItem();
     const isScrollEnd = this.isScrollEnd(props);
-    const isLastItem = this.isLastItem();
+    const isLastItem = this.isLastItem(props);
 
     const atStart = isScrollStart || isFirstItem;
     const atEnd = isScrollEnd || isLastItem;

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -89,7 +89,7 @@ class SlideshowView extends React.Component {
     return this.scrollPosition() <= 1;
   }
 
-  isScrollEnd() {
+  isScrollEnd(props = this.props) {
     const { slideshowLoop, slideAnimation } = this.props.options;
     if (
       slideshowLoop ||
@@ -101,7 +101,7 @@ class SlideshowView extends React.Component {
     return (
       this.isAllItemsLoaded() &&
       this.scrollPositionAtTheAndOfTheGallery() >=
-        Math.floor(this.getScrollElementWidth())
+        Math.floor(this.getScrollElementWidth(props))
     );
   }
 
@@ -121,8 +121,8 @@ class SlideshowView extends React.Component {
     return visibleItemsCount >= totalItemsCount;
   }
 
-  getScrollElementWidth() {
-    const { galleryStructure } = this.props;
+  getScrollElementWidth(props = this.props) {
+    const { galleryStructure } = props;
     const { imageMargin } = this.props.options;
     return galleryStructure.width - imageMargin / 2;
   }
@@ -1193,7 +1193,7 @@ class SlideshowView extends React.Component {
       );
     }
     if (this.props.totalItemsCount !== props.totalItemsCount) {
-      this.removeArrowsIfNeeded();
+      this.removeArrowsIfNeeded(props);
     }
     if (isEditMode() || isPreviewMode()) {
       if (
@@ -1210,13 +1210,13 @@ class SlideshowView extends React.Component {
       props.options.isAutoSlideshow && props.options.playButtonForAutoSlideShow;
   }
 
-  removeArrowsIfNeeded() {
-    const { isRTL } = this.props.options;
+  removeArrowsIfNeeded(props = this.props) {
+    const { isRTL } = props.options;
     const { hideLeftArrow, hideRightArrow } = this.state;
 
     const isScrollStart = this.isScrollStart();
     const isFirstItem = this.isFirstItem();
-    const isScrollEnd = this.isScrollEnd();
+    const isScrollEnd = this.isScrollEnd(props);
     const isLastItem = this.isLastItem();
 
     const atStart = isScrollStart || isFirstItem;


### PR DESCRIPTION
Apply #1252 and #1253 on V4:
Set slider arrow visibly on any change in gallery container dimenations.
When UNSAFE_componentWillReceiveProps in it's inner function we are calculating gallery position according to the old props (happens before props are changing).