### PR TITLE
Bug fix - Show all relevant thumbnails

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -83,7 +83,8 @@ class NavigationPanel extends React.Component {
           style={{ ...thumbnailsStyle }}
         >
           {items.map(({ thumbnailItem, location, idx }) => {
-            const highlighted = idx === activeIndex % items.length;
+            const highlighted =
+              idx === activeIndex % clearedGalleryItems.length;
             const itemStyle = {
               width: thumbnailSize,
               height: thumbnailSize,

--- a/packages/gallery/src/components/helpers/thumbnailsLogic.ts
+++ b/packages/gallery/src/components/helpers/thumbnailsLogic.ts
@@ -104,7 +104,8 @@ export function getThumbnailsData({
     minNumOfThumbnails % 2 === 1 ? minNumOfThumbnails : minNumOfThumbnails + 1;
   const thumbnailsInEachSide = (numberOfThumbnails - 1) / 2;
 
-  const itemRangeStart = activeIndexWithOffset - thumbnailsInEachSide;
+  const itemRangeStart =
+    (activeIndexWithOffset % galleryItems.length) - thumbnailsInEachSide;
   const itemRangeEnd = itemRangeStart + numberOfThumbnails;
 
   const itemToDisplay = withInfiniteScroll


### PR DESCRIPTION
- Show all relevant thumbnails by reseting `itemRangeStart` based on the current activeIndex to ensure it doesn't continuously increase.
- Fix the calculation for the highlighted class by applying the modulus operation with the total number of items, rather than just the currently displayed items (`itemsToDisplay`).