### PR TITLE
Show all relevant thumbnails

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -70,7 +70,7 @@ class NavigationPanel extends React.Component {
           style={{ ...thumbnailsStyle }}
         >
           {items.map(({ thumbnailItem, location, idx }) => {
-            const highlighted = idx === activeIndex % items.length;
+            const highlighted = idx === activeIndex % clearedGalleryItems.length;
             const itemStyle = {
               width: options[optionsMap.layoutParams.thumbnails.size],
               height: options[optionsMap.layoutParams.thumbnails.size],

--- a/packages/lib/src/core/helpers/thumbnailsLogic.ts
+++ b/packages/lib/src/core/helpers/thumbnailsLogic.ts
@@ -96,7 +96,7 @@ function getThumbnailsData({
   const numberOfThumbnails = minNumOfThumbnails % 2 === 1 ? minNumOfThumbnails : minNumOfThumbnails + 1;
   const thumbnailsInEachSide = (numberOfThumbnails - 1) / 2;
 
-  const itemRangeStart = activeIndexWithOffset - thumbnailsInEachSide;
+  const itemRangeStart = (activeIndexWithOffset % galleryItems.length) - thumbnailsInEachSide;
   const itemRangeEnd = itemRangeStart + numberOfThumbnails;
 
   const itemToDisplay = withInfiniteScroll


### PR DESCRIPTION
- Show all relevant thumbnails by reseting `itemRangeStart` based on the current activeIndex to ensure it doesn't continuously increase.
- Fix the calculation for the highlighted class by applying the modulus operation with the total number of items, rather than just the currently displayed items (`itemsToDisplay`).