### PR TITLE
up default bandwidth estimation and start level

### DIFF
--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -250,8 +250,9 @@ class VideoItem extends React.Component {
             forceHLS: this.shouldUseHlsPlayer(),
             forceVideo: this.shouldForceVideoForHLS(),
             hlsOptions: {
+              startLevel: 3,
               testBandwidth: false,
-              abrEwmaDefaultEstimate: 6000000,
+              abrEwmaDefaultEstimate: 7000000,
             },
           },
         }}


### PR DESCRIPTION
Up default bandwidth estimation and starting level to prevent HLS video starting with low quality