### PR TITLE
Fix videos play button z-index for fade animation

### DIFF
--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -725,7 +725,7 @@ class ItemView extends React.Component {
           left: isRTL ? 'auto' : 0,
           right: !isRTL ? 'auto' : 0,
           pointerEvents: activeIndex === idx ? 'auto' : 'none',
-          zIndex: activeIndex === idx ? 0 : 1,
+          zIndex: activeIndex === idx ? 1 : 0,
         };
         break;
       case GALLERY_CONSTS.slideAnimations.DECK:


### PR DESCRIPTION
In fade animation, the play button of the video had the opposite z-index which caused it to play the wrong video.