### PR TITLE
don't setTimeout when eventListener callback is not set

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -709,7 +709,10 @@ export class GalleryContainer extends React.Component {
       switch (eventName) {
         case GALLERY_CONSTS.events.ITEM_ACTION_TRIGGERED:
         case GALLERY_CONSTS.events.ITEM_CLICKED:
-          setTimeout(this.props.eventsListener(eventName, eventData, event), 0);
+          const listenerCallback = this.props.eventsListener(eventName, eventData, event);
+          if (listenerCallback) {
+            setTimeout(listenerCallback, 0);
+          }
           break;
         default:
           this.props.eventsListener(eventName, eventData, event);

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -708,12 +708,13 @@ export class GalleryContainer extends React.Component {
     if (typeof this.props.eventsListener === 'function') {
       switch (eventName) {
         case GALLERY_CONSTS.events.ITEM_ACTION_TRIGGERED:
-        case GALLERY_CONSTS.events.ITEM_CLICKED:
+        case GALLERY_CONSTS.events.ITEM_CLICKED: {
           const listenerCallback = this.props.eventsListener(eventName, eventData, event);
           if (listenerCallback) {
             setTimeout(listenerCallback, 0);
           }
           break;
+        }
         default:
           this.props.eventsListener(eventName, eventData, event);
       }


### PR DESCRIPTION
In node environment, when setting timeout with `setTimeout(undefined, 0)`, it produces error `TypeError [ERR_INVALID_ARG_TYPE]: The "callback" argument must be of type function. Received undefined`. It seems like in this instance is always(?) undefined as `_eventsListener` which is passed always return undefined here: https://github.com/wix-incubator/pro-gallery/blob/7662ecbb93d782dbea58cccdb7d44f2615a9802f/packages/gallery/src/components/gallery/index.tsx#L59


This ussually happens in unit test. Seems like browser can handle this.

Maybe this `setTimeout` can be removed overall?