### PR TITLE
fix hydration issue by preventing template creation during SSR

### DIFF
--- a/packages/gallery/src/components/item/media/GalleryUI.tsx
+++ b/packages/gallery/src/components/item/media/GalleryUI.tsx
@@ -1,25 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useGalleryUI } from '../../../context/GalleryContext';
-const galleryUiComponents = {
-  videoPlayButton: React.lazy(() => import(/* webpackChunkName: "defaultPlayButton" */ './playButton')),
-  rotateArrow: React.lazy(() => import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow')),
+
+type ComponentType = React.ComponentType<{ size: number }>;
+
+interface GalleryComponents {
+  videoPlayButton: ComponentType;
+  rotateArrow: ComponentType;
+}
+
+const galleryUiComponents: Record<string, React.LazyExoticComponent<ComponentType>> = {
+  videoPlayButton: React.lazy(() => 
+    import(/* webpackChunkName: "defaultPlayButton" */ './playButton')
+      .then(module => ({
+        default: (props) => (
+          <div style={{ display: 'contents' }}>
+            <module.default {...props} />
+          </div>
+        )
+      }))
+  ),
+  rotateArrow: React.lazy(() => 
+    import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow')
+      .then(module => ({
+        default: (props) => (
+          <div style={{ display: 'contents' }}>
+            <module.default {...props} />
+          </div>
+        )
+      }))
+  ),
 };
+
 interface GalleryUIProps {
   size: number;
-  type: 'videoPlayButton' | 'rotateArrow';
+  type: keyof GalleryComponents;
 }
 
 export const GalleryUI = ({ type, size }: GalleryUIProps): JSX.Element => {
-  let Component;
-
+  const [isMounted, setIsMounted] = useState(false);
   const galleryUI = useGalleryUI();
-  if (typeof galleryUI?.[type] === 'function') {
-    return galleryUI[type](size);
-  } else if (galleryUiComponents[type]) {
-    Component = galleryUiComponents[type];
-  } else {
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
     return <></>;
   }
+
+  if (typeof galleryUI?.[type] === 'function') {
+    return galleryUI[type](size);
+  }
+
+  const Component = galleryUiComponents[type];
+  
+  if (!Component) {
+    return <></>;
+  }
+
   return (
     <React.Suspense fallback={<></>}>
       <Component size={size} />

--- a/packages/gallery/src/components/item/media/GalleryUI.tsx
+++ b/packages/gallery/src/components/item/media/GalleryUI.tsx
@@ -9,25 +9,23 @@ interface GalleryComponents {
 }
 
 const galleryUiComponents: Record<string, React.LazyExoticComponent<ComponentType>> = {
-  videoPlayButton: React.lazy(() => 
-    import(/* webpackChunkName: "defaultPlayButton" */ './playButton')
-      .then(module => ({
-        default: (props) => (
-          <div style={{ display: 'contents' }}>
-            <module.default {...props} />
-          </div>
-        )
-      }))
+  videoPlayButton: React.lazy(() =>
+    import(/* webpackChunkName: "defaultPlayButton" */ './playButton').then((module) => ({
+      default: (props) => (
+        <div style={{ display: 'contents' }}>
+          <module.default {...props} />
+        </div>
+      ),
+    }))
   ),
-  rotateArrow: React.lazy(() => 
-    import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow')
-      .then(module => ({
-        default: (props) => (
-          <div style={{ display: 'contents' }}>
-            <module.default {...props} />
-          </div>
-        )
-      }))
+  rotateArrow: React.lazy(() =>
+    import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow').then((module) => ({
+      default: (props) => (
+        <div style={{ display: 'contents' }}>
+          <module.default {...props} />
+        </div>
+      ),
+    }))
   ),
 };
 
@@ -53,7 +51,7 @@ export const GalleryUI = ({ type, size }: GalleryUIProps): JSX.Element => {
   }
 
   const Component = galleryUiComponents[type];
-  
+
   if (!Component) {
     return <></>;
   }

--- a/packages/gallery/src/components/item/media/GalleryUI.tsx
+++ b/packages/gallery/src/components/item/media/GalleryUI.tsx
@@ -8,25 +8,9 @@ interface GalleryComponents {
   rotateArrow: ComponentType;
 }
 
-const galleryUiComponents: Record<string, React.LazyExoticComponent<ComponentType>> = {
-  videoPlayButton: React.lazy(() =>
-    import(/* webpackChunkName: "defaultPlayButton" */ './playButton').then((module) => ({
-      default: (props) => (
-        <div style={{ display: 'contents' }}>
-          <module.default {...props} />
-        </div>
-      ),
-    }))
-  ),
-  rotateArrow: React.lazy(() =>
-    import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow').then((module) => ({
-      default: (props) => (
-        <div style={{ display: 'contents' }}>
-          <module.default {...props} />
-        </div>
-      ),
-    }))
-  ),
+const galleryUiComponents = {
+  videoPlayButton: React.lazy(() => import(/* webpackChunkName: "defaultPlayButton" */ './playButton')),
+  rotateArrow: React.lazy(() => import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow')),
 };
 
 interface GalleryUIProps {


### PR DESCRIPTION
Disable SSR `<template>` creation issue in Gallery UI components by implementing client-side only rendering for lazy-loaded components.

Make the videoPlayButton and rotateArrow components render only on the client side and wraps them properly to prevent React from creating unwanted `<template>` tags, while keeping all the original functionality intact.

Prevents hydration issues.