### PR TITLE
convert dynamic imports to static to remove React.Suspense and React.lazy

### DIFF
--- a/packages/gallery/src/components/item/media/GalleryUI.tsx
+++ b/packages/gallery/src/components/item/media/GalleryUI.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useGalleryUI } from '../../../context/GalleryContext';
+import PlayButton from './playButton';
+import RotateArrow from './rotateArrow';
+
 const galleryUiComponents = {
-  videoPlayButton: React.lazy(() => import(/* webpackChunkName: "defaultPlayButton" */ './playButton')),
-  rotateArrow: React.lazy(() => import(/* webpackChunkName: "defaultRotateArrow" */ './rotateArrow')),
+  videoPlayButton: PlayButton,
+  rotateArrow: RotateArrow,
 };
+
 interface GalleryUIProps {
   size: number;
   type: 'videoPlayButton' | 'rotateArrow';
@@ -20,9 +24,5 @@ export const GalleryUI = ({ type, size }: GalleryUIProps): JSX.Element => {
   } else {
     return <></>;
   }
-  return (
-    <React.Suspense fallback={<></>}>
-      <Component size={size} />
-    </React.Suspense>
-  );
+  return <Component size={size} />;
 };


### PR DESCRIPTION
Remove `React.Suspense` and `React.lazy`.
The play button is now server-side rendered as well, preventing hydration issues.

As shown in the attached image when `ssrOnly=true`
![Screenshot 2024-11-18 at 15 51 37](https://github.com/user-attachments/assets/003b0b6c-dd14-4a31-9310-16ee0db846df)
