### PR TITLE
Add playInline as a React Player prop for playing videos on mobile

### DIFF
--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -82,7 +82,7 @@ class VideoItem extends React.Component {
   }
 
   shouldUseHlsPlayer() {
-    return this.isHLSVideo(); // && !utils.isiOS();
+    return this.isHLSVideo() && !utils.isiOS();
   }
 
   shouldForceVideoForHLS() {

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -82,7 +82,7 @@ class VideoItem extends React.Component {
   }
 
   shouldUseHlsPlayer() {
-    return this.isHLSVideo() && !utils.isiOS();
+    return this.isHLSVideo(); // && !utils.isiOS();
   }
 
   shouldForceVideoForHLS() {

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -76,8 +76,8 @@ class VideoItem extends React.Component {
   isHLSVideo() {
     return (
       this.props.videoUrl &&
-      (this.props.videoUrl.includes('/hls') ||
-        this.props.videoUrl.includes('.m3u8'))
+      (this.props.videoUrl.toLowerCase().includes('/hls') ||
+        this.props.videoUrl.toLowerCase().includes('.m3u8'))
     );
   }
 
@@ -179,7 +179,7 @@ class VideoItem extends React.Component {
       muted: !this.props.options.videoSound,
       preload: 'metadata',
       style: getStyle(isCrop, isWiderThenContainer),
-      type: 'video/mp4',
+      type: utils.isiOS() ? 'application/x-mpegURL' : 'video/mp4', // Specify correct MIME type for iOS
     };
 
     if (shouldCreateVideoPlaceholder(this.props.options)) {

--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -173,6 +173,7 @@ class VideoItem extends React.Component {
         );
 
     const attributes = {
+      playInline: true,
       controlsList: 'nodownload',
       disablePictureInPicture: true,
       muted: !this.props.options.videoSound,


### PR DESCRIPTION
Add the `playsInline` attribute our PlayerElement to enable inline playback on mobile devices, preventing videos to fail.
We already had `playsinline` is the standard HTML5 attribute for enabling inline video playback on mobile devices, while playsInline is a prop used in React Player to achieve the same functionality within React applications. Both serve to prevent videos from automatically entering fullscreen mode.