### PR TITLE
[A11Y] - hide not active videos controls to prevent focus lost

### DIFF
--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -265,7 +265,10 @@ class VideoItem extends React.Component {
             this.setState({ shouldPlay: false });
           }
         }}
-        controls={this.props.options.showVideoControls}
+        controls={
+          this.props.activeIndex === this.props.idx &&
+          this.props.options.showVideoControls
+        }
         config={{
           file: {
             attributes,


### PR DESCRIPTION
in expand mode, when going over galleries with videos, we load amount of videos to make performance better. 
this caused when going over the expand mode with TAB, focus lost due to focus that goes through not activeIdx videos controls. 
in this change we only show active video controls and preventing focus from getting lost :) 