### PR TITLE
remove block for active element change in mobile

### DIFF
--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -7,7 +7,7 @@ import {
 } from 'pro-gallery-lib';
 
 function shouldChangeActiveElement() {
-  return (isSiteMode() || isSEOMode()) && !utils.isMobile() && window.document;
+  return (isSiteMode() || isSEOMode()) && window.document;
 }
 
 export function onAnchorFocus({


### PR DESCRIPTION
This is to "solve" the case where keys are used in mobile view. There should not be a blocker of using keys to navigate the gallery in a11y when we are in mobile view.

That being said, this doesn't explain why it was added in the first place and should be thoroughly checked.
A mitigation could be to keep the !mobile and integrate it with a settings.isAccessible to only remove this block when the isAccessible is on true. (this would be much less of a change for users in production). Your call.