### PR TITLE
A11Y - remove block for active element change in mobile

### DIFF
--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -6,7 +6,11 @@ import {
   GALLERY_CONSTS,
 } from 'pro-gallery-lib';
 
-function shouldChangeActiveElement() {
+function shouldChangeActiveElement(isAccessible) {
+  if (isAccessible) {
+    // to reduce the number of users experiencing the change
+    return (isSiteMode() || isSEOMode()) && window.document;
+  }
   return (isSiteMode() || isSEOMode()) && !utils.isMobile() && window.document;
 }
 
@@ -14,8 +18,9 @@ export function onAnchorFocus({
   itemContainer,
   enableExperimentalFeatures,
   itemAnchor,
+  isAccessible,
 }) {
-  if (shouldChangeActiveElement() && enableExperimentalFeatures) {
+  if (shouldChangeActiveElement(isAccessible) && enableExperimentalFeatures) {
     /* Relevant only for Screen-Reader cases:
          When we navigate on the accessibility tree, screen readers stops and focuses on the <a> tag,
          so it will not go deeper to the item-container keyDown event */
@@ -40,10 +45,11 @@ export function changeActiveElementIfNeeded({
   prevProps,
   currentProps,
   itemActionRef,
+  isAccessible,
 }) {
   try {
     if (
-      shouldChangeActiveElement() &&
+      shouldChangeActiveElement(isAccessible) &&
       window.document.activeElement.className
     ) {
       const isGalleryItemAction = isThisGalleryElementInFocus(

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -961,6 +961,7 @@ class ItemView extends React.Component {
       prevProps,
       currentProps: this.props,
       itemActionRef: this.itemActionRef,
+      isAccessible: this.props.settings?.isAccessible,
     });
   }
 
@@ -1106,6 +1107,7 @@ class ItemView extends React.Component {
         itemAnchor: this.itemAnchor,
         enableExperimentalFeatures: this.props.enableExperimentalFeatures,
         itemContainer: this.itemContainer,
+        isAccessible: this.props.settings?.isAccessible,
       });
     };
     const linkParams = getLinkParams(this.props);


### PR DESCRIPTION
This is to "solve" the case where keys are used in mobile view.
added to this [PR](https://github.com/wix-incubator/pro-gallery/pull/1428) props.isAccessible protection to embrace the change with as few distractions as possible.