### PR TITLE
A11Y - remove block for active element change in mobile

### DIFF
--- a/packages/gallery/src/components/item/itemHelper.js
+++ b/packages/gallery/src/components/item/itemHelper.js
@@ -1,7 +1,7 @@
 import { window, utils, isSiteMode, isSEOMode, GALLERY_CONSTS, optionsMap } from 'pro-gallery-lib';
 
 function shouldChangeActiveElement() {
-  return (isSiteMode() || isSEOMode()) && !utils.isMobile() && window.document;
+  return (isSiteMode() || isSEOMode()) && window.document;
 }
 
 export function onAnchorFocus({ itemContainer, enableExperimentalFeatures, itemAnchor }) {


### PR DESCRIPTION
This is to "solve" the case where keys are used in mobile view. There should not be a blocker of using keys to navigate the gallery in a11y when we are in mobile view.