### PR TITLE
Assign role="img" to images with tabIndex

### DIFF
--- a/packages/gallery/src/components/item/imageItem.js
+++ b/packages/gallery/src/components/item/imageItem.js
@@ -197,7 +197,6 @@ class ImageItem extends React.Component {
           data-idx={idx}
           src={src}
           alt={altText}
-          tabIndex="0"
           onLoad={this.handleHighResImageLoad}
           loading={this.props.isPrerenderMode ? 'lazy' : 'eager'}
           style={{


### PR DESCRIPTION
Focusable elements with a `tabIndex` attribute should have an appropriate `role` assigned to them. That way screen-readers will correctly recognize what's focused. 

<img width="2145" alt="image" src="https://github.com/user-attachments/assets/feec7ee5-b7ae-49fb-8881-df3c198dc4ba" />

https://www.w3.org/TR/WCAG22/#name-role-value