### PR TITLE
[A11Y] - adding a11y semantics to item

### DIFF
--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -771,8 +771,8 @@ class ItemView extends React.Component {
     const mapTypeToLabel = {
       dummy: '',
       text: htmlContent,
-      video: alt || 'Untitled video',
-      image: alt || 'Untitled image',
+      video: alt || type || '',
+      image: alt || type || '',
     };
     const label = mapTypeToLabel[type];
     return label + (options.isStoreGallery ? ', Buy Now' : '');


### PR DESCRIPTION
aria-label attribute of the item uses generic role, need to specify the type. 
approved already in [V4](https://github.com/wix-incubator/pro-gallery/pull/1426/files).