### PR TITLE
Fix esm build tree-shaking on esbuild consumers

### DIFF
--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "watch": "tsc -w",
     "start": "tsc -w -p tsconfig-dev.json",
-    "build": "tsc && tsc -p tsconfig-cjs.json && echo \"{ \\\"type\\\": \\\"module\\\" }\" > dist/esm/package.json",
+    "build": "tsc && tsc -p tsconfig-cjs.json && cp ../../scripts/esm_package.json dist/esm/package.json",
     "unit": "NODE_OPTIONS=\"--import=tsx\" mocha test/*.spec.*",
     "test": "echo 'no test in wix CI'",
     "lint": "eslint \"{src,test}/**/*.{js,jsx,ts}\"",

--- a/packages/gallery/package.json
+++ b/packages/gallery/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "watch": "npm run start",
-    "build": "tsc && tsc -p tsconfig-cjs.json && echo \"{ \\\"type\\\": \\\"module\\\" }\" > dist/esm/package.json && npm run css-compile",
+    "build": "tsc && tsc -p tsconfig-cjs.json && cp ../../scripts/esm_package.json dist/esm/package.json && npm run css-compile",
     "css-compile": "sass --style expanded --source-map --embed-sources --no-error-css src/components/styles/gallery.scss:dist/statics/main.css",
     "start": "concurrently \"npm run css-watch\" \"npm run code-watch\"",
     "code-watch": "tsc && tsc -w -p tsconfig-esm-dev.json",

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "watch": "tsc -w",
     "start": "tsc -p tsconfig.json -w",
-    "build": "tsc && tsc -p tsconfig-cjs.json && echo \"{ \\\"type\\\": \\\"module\\\" }\" > dist/esm/package.json",
+    "build": "tsc && tsc -p tsconfig-cjs.json && cp ../../scripts/esm_package.json dist/esm/package.json",
     "unit": "NODE_OPTIONS=\"--import=tsx\" mocha test/*.spec.*",
     "test": "echo 'no test in wix CI'",
     "lint": "eslint \"{src,test}/**/*.{js,jsx,ts}\"",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "watch": "tsc -w",
     "start": "tsc -w -p tsconfig-dev.json",
-    "build": "npm run generateValidationFunction && tsc -p tsconfig-cjs.json && tsc && echo \"{ \\\"type\\\": \\\"module\\\" }\" > dist/esm/package.json",
+    "build": "npm run generateValidationFunction && tsc -p tsconfig-cjs.json && tsc && cp ../../scripts/esm_package.json dist/esm/package.json",
     "generateValidationFunction": "node buildScripts/buildRuntimeValidateFunctionFromTypes.js",
     "unit": "NODE_OPTIONS=\"--import=tsx\" mocha test/*.spec.*",
     "test": "echo 'no test in wix CI'",

--- a/scripts/esm_package.json
+++ b/scripts/esm_package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}


### PR DESCRIPTION
It looks that if esbuild doesn't find 'sideEffects' field on the esm specific package json it doesn't run tree shaking. Adding this flag to all esm package.json's