### PR TITLE
Add conditional rendering for item action based on item count

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -891,6 +891,7 @@ export class GalleryContainer extends React.Component {
           galleryContainerId={`pro-gallery-container-${this.props.id}`}
           scrollTop={this.state?.scrollPosition?.top}
           isScrollLessGallery={this.getIsScrollLessGallery(this.state.options)}
+          hideItemAction={this.props.hideItemAction}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -891,7 +891,7 @@ export class GalleryContainer extends React.Component {
           galleryContainerId={`pro-gallery-container-${this.props.id}`}
           scrollTop={this.state?.scrollPosition?.top}
           isScrollLessGallery={this.getIsScrollLessGallery(this.state.options)}
-          hideItemAction={this.props.hideItemAction}
+          disableItemFocus={this.props.disableItemFocus}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -619,6 +619,7 @@ class SlideshowView extends React.Component {
         return layoutGroupView.map(({ group, shouldRender }) => {
           return group.rendered
             ? React.createElement(GroupView, {
+                hideItemAction: this.props.hideItemAction,
                 activeIndex: this.state.activeIndex,
                 slideAnimation: this.props.options.behaviourParams_gallery_horizontal_slideAnimation,
                 allowLoop:

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -619,7 +619,7 @@ class SlideshowView extends React.Component {
         return layoutGroupView.map(({ group, shouldRender }) => {
           return group.rendered
             ? React.createElement(GroupView, {
-                hideItemAction: this.props.hideItemAction,
+                disableItemFocus: this.props.disableItemFocus,
                 activeIndex: this.state.activeIndex,
                 slideAnimation: this.props.options.behaviourParams_gallery_horizontal_slideAnimation,
                 allowLoop:

--- a/packages/gallery/src/components/group/groupView.js
+++ b/packages/gallery/src/components/group/groupView.js
@@ -15,7 +15,7 @@ class GroupView extends React.Component {
       const props = item.renderProps({ ...this.props.galleryConfig, visible });
       return React.createElement(itemView, {
         ...props,
-        onlyOneItem: this.props.items.length === 1,
+        hideItemAction: this.props.hideItemAction,
         type: empty ?? false ? 'dummy' : props.type,
       });
     });

--- a/packages/gallery/src/components/group/groupView.js
+++ b/packages/gallery/src/components/group/groupView.js
@@ -15,7 +15,7 @@ class GroupView extends React.Component {
       const props = item.renderProps({ ...this.props.galleryConfig, visible });
       return React.createElement(itemView, {
         ...props,
-        hideItemAction: this.props.hideItemAction,
+        disableItemFocus: this.props.disableItemFocus,
         type: empty ?? false ? 'dummy' : props.type,
       });
     });

--- a/packages/gallery/src/components/group/groupView.js
+++ b/packages/gallery/src/components/group/groupView.js
@@ -15,6 +15,7 @@ class GroupView extends React.Component {
       const props = item.renderProps({ ...this.props.galleryConfig, visible });
       return React.createElement(itemView, {
         ...props,
+        onlyOneItem: this.props.items.length === 1,
         type: empty ?? false ? 'dummy' : props.type,
       });
     });

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -999,7 +999,7 @@ class ItemView extends React.Component {
         onKeyUp={this.onContainerKeyUp}
         onClick={this.onItemWrapperClick}
       >
-        {this.props.hideItemAction ? null : (
+        {this.props.disableItemFocus ? null : (
           <div
             data-idx={idx}
             id={'item-action-' + id}

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -999,7 +999,7 @@ class ItemView extends React.Component {
         onKeyUp={this.onContainerKeyUp}
         onClick={this.onItemWrapperClick}
       >
-        {this.props.onlyOneItem ? null : (
+        {this.props.hideItemAction ? null : (
           <div
             data-idx={idx}
             id={'item-action-' + id}

--- a/packages/gallery/src/components/item/itemView.js
+++ b/packages/gallery/src/components/item/itemView.js
@@ -999,20 +999,22 @@ class ItemView extends React.Component {
         onKeyUp={this.onContainerKeyUp}
         onClick={this.onItemWrapperClick}
       >
-        <div
-          data-idx={idx}
-          id={'item-action-' + id}
-          className="item-action"
-          ref={(ref) => (this.itemActionRef = ref)}
-          onKeyUp={this.onContainerKeyUp}
-          tabIndex={this.getItemContainerTabIndex()}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
-          data-hook={'item-action'}
-          {...(itemAriaLabel && { ['aria-label']: itemAriaLabel })}
-          {...(itemAriaRole && { role: itemAriaRole })}
-          {...(itemAriaHaspopup && { ['aria-haspopup']: itemAriaHaspopup ? 'dialog' : '' })}
-        ></div>
+        {this.props.onlyOneItem ? null : (
+          <div
+            data-idx={idx}
+            id={'item-action-' + id}
+            className="item-action"
+            ref={(ref) => (this.itemActionRef = ref)}
+            onKeyUp={this.onContainerKeyUp}
+            tabIndex={this.getItemContainerTabIndex()}
+            onFocus={this.onFocus}
+            onBlur={this.onBlur}
+            data-hook={'item-action'}
+            {...(itemAriaLabel && { ['aria-label']: itemAriaLabel })}
+            {...(itemAriaRole && { role: itemAriaRole })}
+            {...(itemAriaHaspopup && { ['aria-haspopup']: itemAriaHaspopup ? 'dialog' : '' })}
+          ></div>
+        )}
         {this.getTopInfoElementIfNeeded()}
         {this.getLeftInfoElementIfNeeded()}
         <div


### PR DESCRIPTION
We have an a11y problem when there is only one item in slideshow view.

There is a redundant tab stop.

![Screenshot 2025-05-27 at 10 51 36](https://github.com/user-attachments/assets/08ceb333-ddab-43d6-98cd-f00b6330f669)

My contribution makes it so that if the slideshow consists of only one item we do not render `item-action`