### PR TITLE
provide inline sourcemaps

### DIFF
--- a/packages/blueprints/tsconfig-cjs.json
+++ b/packages/blueprints/tsconfig-cjs.json
@@ -18,6 +18,7 @@
     "declarationDir": "dist/types",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "importHelpers": true,
     "esModuleInterop": true,
     "jsx": "react",

--- a/packages/gallery/tsconfig-cjs.json
+++ b/packages/gallery/tsconfig-cjs.json
@@ -19,6 +19,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "importHelpers": true,
     "esModuleInterop": true,
     "jsx": "react",

--- a/packages/layouts/tsconfig-cjs.json
+++ b/packages/layouts/tsconfig-cjs.json
@@ -18,6 +18,7 @@
     "declarationDir": "dist/types",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "importHelpers": true,
     "esModuleInterop": true,
     "jsx": "react",

--- a/packages/lib/tsconfig-cjs.json
+++ b/packages/lib/tsconfig-cjs.json
@@ -19,6 +19,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "importHelpers": true,
     "esModuleInterop": true,
     "jsx": "react",


### PR DESCRIPTION
Current sourcemaps appear to be broken because pro gallery does not ship `dist/src` files, which the sourcemaps point to.
The solution is to inline the sources.