### PR TITLE
[Pro-gallery, lib]: Add experiment for ignoring prerender mode for invisible items

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -277,13 +277,13 @@ export class GalleryContainer extends React.Component {
     );
   }
 
-  getVisibleItems(items, container, isPrerenderMode, shouldReturnAllItemsInPrerenderMode = true) {
+  getVisibleItems(items, container, isPrerenderMode, bypassPrerenderMode = false) {
     const { gotFirstScrollEvent } = this.state;
     const scrollY = this.state?.scrollPosition?.top || 0;
     const { galleryHeight, scrollBase, galleryWidth } = container;
 
     if (
-      (isPrerenderMode && shouldReturnAllItemsInPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
+      (isPrerenderMode && !bypassPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
       isSEOMode() ||
       isEditMode() ||
       gotFirstScrollEvent ||
@@ -894,7 +894,7 @@ export class GalleryContainer extends React.Component {
           scrollTop={this.state?.scrollPosition?.top}
           isScrollLessGallery={this.getIsScrollLessGallery(this.state.options)}
           disableItemFocus={this.props.disableItemFocus}
-          shouldEnablePrerenderMode={this.props.shouldEnablePrerenderMode}
+          experimentalFeatures={this.props.experimentalFeatures}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -277,12 +277,13 @@ export class GalleryContainer extends React.Component {
     );
   }
 
-  getVisibleItems(items, container, isPrerenderMode) {
+  getVisibleItems(items, container, isPrerenderMode, shouldReturnAllItemsInPrerenderMode = true) {
     const { gotFirstScrollEvent } = this.state;
     const scrollY = this.state?.scrollPosition?.top || 0;
     const { galleryHeight, scrollBase, galleryWidth } = container;
+
     if (
-      isPrerenderMode || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
+      (isPrerenderMode && shouldReturnAllItemsInPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
       isSEOMode() ||
       isEditMode() ||
       gotFirstScrollEvent ||
@@ -893,6 +894,7 @@ export class GalleryContainer extends React.Component {
           scrollTop={this.state?.scrollPosition?.top}
           isScrollLessGallery={this.getIsScrollLessGallery(this.state.options)}
           disableItemFocus={this.props.disableItemFocus}
+          shouldEnablePrerenderMode={this.props.shouldEnablePrerenderMode}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -181,7 +181,7 @@ class GalleryView extends React.Component {
       galleryStructure.galleryItems,
       container,
       this.props.isPrerenderMode,
-      this.props.experimentalFeatures?.shouldReturnAllItemsInPrerenderMode
+      this.props.experimentalFeatures?.bypassPrerenderMode
     );
     const itemsWithVirtualizationData = getItemsInViewportOrMarginByScrollLocation({
       items,

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -177,7 +177,12 @@ class GalleryView extends React.Component {
       ? 'auto'
       : this.props.container.galleryWidth - options[optionsMap.layoutParams.structure.itemSpacing];
 
-    const items = getVisibleItems(galleryStructure.galleryItems, container, this.props.isPrerenderMode);
+    const items = getVisibleItems(
+      galleryStructure.galleryItems,
+      container,
+      this.props.isPrerenderMode,
+      this.props.experimentalFeatures?.shouldReturnAllItemsInPrerenderMode
+    );
     const itemsWithVirtualizationData = getItemsInViewportOrMarginByScrollLocation({
       items,
       options,

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -95,7 +95,12 @@ class SlideshowView extends React.Component {
 
   isAllItemsLoaded(props = this.props) {
     const { totalItemsCount, getVisibleItems, galleryStructure, container, isPrerenderMode } = props;
-    const visibleItemsCount = getVisibleItems(galleryStructure.galleryItems, container, isPrerenderMode).length;
+    const visibleItemsCount = getVisibleItems(
+      galleryStructure.galleryItems,
+      container,
+      isPrerenderMode,
+      props.experimentalFeatures?.shouldReturnAllItemsInPrerenderMode
+    ).length;
     return visibleItemsCount >= totalItemsCount;
   }
 
@@ -575,7 +580,7 @@ class SlideshowView extends React.Component {
     const { state, props } = this;
     const { options, virtualizationSettings, getVisibleItems, isPrerenderMode } = props;
     const { activeIndex } = state;
-    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode);
+    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode, true);
     const galleryWidth = this.props.galleryContainerRef?.clientWidth || container.galleryWidth || 0;
 
     return getItemsInViewportOrMarginByActiveGroup({

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -580,7 +580,12 @@ class SlideshowView extends React.Component {
     const { state, props } = this;
     const { options, virtualizationSettings, getVisibleItems, isPrerenderMode } = props;
     const { activeIndex } = state;
-    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode, props.experimentalFeatures?.bypassPrerenderMode);
+    const groups = getVisibleItems(
+      galleryGroups,
+      container,
+      isPrerenderMode,
+      props.experimentalFeatures?.bypassPrerenderMode
+    );
     const galleryWidth = this.props.galleryContainerRef?.clientWidth || container.galleryWidth || 0;
 
     return getItemsInViewportOrMarginByActiveGroup({

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -99,7 +99,7 @@ class SlideshowView extends React.Component {
       galleryStructure.galleryItems,
       container,
       isPrerenderMode,
-      props.experimentalFeatures?.shouldReturnAllItemsInPrerenderMode
+      props.experimentalFeatures?.bypassPrerenderMode
     ).length;
     return visibleItemsCount >= totalItemsCount;
   }
@@ -580,7 +580,7 @@ class SlideshowView extends React.Component {
     const { state, props } = this;
     const { options, virtualizationSettings, getVisibleItems, isPrerenderMode } = props;
     const { activeIndex } = state;
-    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode, true);
+    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode, props.experimentalFeatures?.bypassPrerenderMode);
     const galleryWidth = this.props.galleryContainerRef?.clientWidth || container.galleryWidth || 0;
 
     return getItemsInViewportOrMarginByActiveGroup({

--- a/packages/lib/src/common/interfaces/galleryTypes.ts
+++ b/packages/lib/src/common/interfaces/galleryTypes.ts
@@ -33,6 +33,9 @@ export interface GalleryProps {
   enableExperimentalFeatures?: boolean;
   virtualizationSettings?: VirtualizationSettings;
   disableItemFocus?: boolean;
+  experimentalFeatures?: {
+    shouldReturnAllItemsInPrerenderMode?: boolean;
+  };
 }
 
 export interface GalleryState {

--- a/packages/lib/src/common/interfaces/galleryTypes.ts
+++ b/packages/lib/src/common/interfaces/galleryTypes.ts
@@ -34,7 +34,7 @@ export interface GalleryProps {
   virtualizationSettings?: VirtualizationSettings;
   disableItemFocus?: boolean;
   experimentalFeatures?: {
-    shouldReturnAllItemsInPrerenderMode?: boolean;
+    bypassPrerenderMode?: boolean;
   };
 }
 


### PR DESCRIPTION
## Context
Sometimes (I couldn't determine in which occasions, but seems to be very rare on strong computers), when gallery has many images (30+), we showcase only the default number of them (i.e 2 or 3).
The rest of them, will be rendered in the next seconds (Amen!).

## Trouble shoot
During the investigation, we found that where we call `getVisibleItems`, we try to return the items when they're shown by the user, and we might hiding them during the prerender mode. This could be the bug.

## What I've Done
- Added experimental features property to support experiments (also in the future).
- Added specific experiment that should ignore prerender mode.