### PR TITLE
[Pro-gallery, lib]: Add experiment for ignoring prerender mode for invisible items

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -335,12 +335,17 @@ export class GalleryContainer extends React.Component {
     );
   }
 
-  getVisibleItems(items, container, isPrerenderMode) {
+  getVisibleItems(
+    items,
+    container,
+    isPrerenderMode,
+    bypassPrerenderMode = false
+  ) {
     const { gotFirstScrollEvent } = this.state;
     const scrollY = this.state?.scrollPosition?.top || 0;
     const { galleryHeight, scrollBase, galleryWidth } = container;
     if (
-      isPrerenderMode || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
+      (isPrerenderMode && !bypassPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
       isSEOMode() ||
       isEditMode() ||
       gotFirstScrollEvent ||
@@ -975,6 +980,7 @@ export class GalleryContainer extends React.Component {
           scrollTop={this.state?.scrollPosition?.top}
           isScrollLessGallery={this.getIsScrollLessGallery(this.state.options)}
           shouldDisableItemFocus={this.props.shouldDisableItemFocus}
+          experimentalFeatures={this.props.experimentalFeatures}
           actions={{
             ...this.props.actions,
             findNeighborItem: this.findNeighborItem,

--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -339,13 +339,13 @@ export class GalleryContainer extends React.Component {
     items,
     container,
     isPrerenderMode,
-    bypassPrerenderMode = false
+    disableVisibleItemsOnPrerenderMode = false
   ) {
     const { gotFirstScrollEvent } = this.state;
     const scrollY = this.state?.scrollPosition?.top || 0;
     const { galleryHeight, scrollBase, galleryWidth } = container;
     if (
-      (isPrerenderMode && !bypassPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
+      (isPrerenderMode && !disableVisibleItemsOnPrerenderMode) || // (used to be isSSR, had a hydrate bug, isPrerenderMode is the way to go in terms of hydrate issues)
       isSEOMode() ||
       isEditMode() ||
       gotFirstScrollEvent ||

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -190,7 +190,7 @@ class GalleryView extends React.Component {
       galleryStructure.galleryItems,
       container,
       this.props.isPrerenderMode,
-      this.props.experimentalFeatures?.bypassPrerenderMode
+      this.props.experimentalFeatures?.disableVisibleItemsOnPrerenderMode
     );
     const itemsWithVirtualizationData =
       getItemsInViewportOrMarginByScrollLocation({

--- a/packages/gallery/src/components/gallery/proGallery/galleryView.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryView.js
@@ -189,7 +189,8 @@ class GalleryView extends React.Component {
     const items = getVisibleItems(
       galleryStructure.galleryItems,
       container,
-      this.props.isPrerenderMode
+      this.props.isPrerenderMode,
+      this.props.experimentalFeatures?.bypassPrerenderMode
     );
     const itemsWithVirtualizationData =
       getItemsInViewportOrMarginByScrollLocation({

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -116,7 +116,8 @@ class SlideshowView extends React.Component {
     const visibleItemsCount = getVisibleItems(
       galleryStructure.galleryItems,
       container,
-      isPrerenderMode
+      isPrerenderMode,
+      props.experimentalFeatures?.bypassPrerenderMode
     ).length;
     return visibleItemsCount >= totalItemsCount;
   }
@@ -645,7 +646,12 @@ class SlideshowView extends React.Component {
       isPrerenderMode,
     } = props;
     const { activeIndex } = state;
-    const groups = getVisibleItems(galleryGroups, container, isPrerenderMode);
+    const groups = getVisibleItems(
+      galleryGroups,
+      container,
+      isPrerenderMode,
+      props.experimentalFeatures?.bypassPrerenderMode
+    );
     const galleryWidth =
       this.props.galleryContainerRef?.clientWidth ||
       container.galleryWidth ||

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -117,7 +117,7 @@ class SlideshowView extends React.Component {
       galleryStructure.galleryItems,
       container,
       isPrerenderMode,
-      props.experimentalFeatures?.bypassPrerenderMode
+      props.experimentalFeatures?.disableVisibleItemsOnPrerenderMode
     ).length;
     return visibleItemsCount >= totalItemsCount;
   }
@@ -650,7 +650,7 @@ class SlideshowView extends React.Component {
       galleryGroups,
       container,
       isPrerenderMode,
-      props.experimentalFeatures?.bypassPrerenderMode
+      props.experimentalFeatures?.disableVisibleItemsOnPrerenderMode
     );
     const galleryWidth =
       this.props.galleryContainerRef?.clientWidth ||

--- a/packages/lib/src/common/interfaces/galleryTypes.ts
+++ b/packages/lib/src/common/interfaces/galleryTypes.ts
@@ -33,6 +33,9 @@ export interface GalleryProps {
   enableExperimentalFeatures?: boolean;
   virtualizationSettings?: VirtualizationSettings;
   shouldDisableItemFocus?: boolean;
+  experimentalFeatures?: {
+    bypassPrerenderMode?: boolean;
+  };
 }
 
 export interface GalleryState {

--- a/packages/lib/src/common/interfaces/galleryTypes.ts
+++ b/packages/lib/src/common/interfaces/galleryTypes.ts
@@ -34,7 +34,7 @@ export interface GalleryProps {
   virtualizationSettings?: VirtualizationSettings;
   shouldDisableItemFocus?: boolean;
   experimentalFeatures?: {
-    bypassPrerenderMode?: boolean;
+    disableVisibleItemsOnPrerenderMode?: boolean;
   };
 }
 


### PR DESCRIPTION
## Context
Sometimes (I couldn't determine in which occasions, but seems to be very rare on strong computers), when gallery has many images (30+), we showcase only the default number of them (i.e 2 or 3).
The rest of them, will be rendered in the next seconds (Amen!).

## Trouble shoot
During the investigation, we found that where we call `getVisibleItems`, we try to return the items when they're shown by the user, and we might hiding them during the prerender mode. This could be the bug.

## What I've Done
- Added experimental features property to support experiments (also in the future).
- Added specific experiment that should ignore prerender mode.