### PR TITLE
Fix: Navigation Arrows Visibility in Editor Mode

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1123,14 +1123,8 @@ class SlideshowView extends React.Component {
     const isScrollEnd = this.isScrollEnd(props);
     const isLastItem = this.isLastItem();
 
-    let atStart, atEnd;
-    if (isEditMode()) {
-      atStart = isFirstItem;
-      atEnd = isLastItem;
-    } else {
-      atStart = isScrollStart || isFirstItem;
-      atEnd = isScrollEnd || isLastItem;
-    }
+    const atStart = isScrollStart || isFirstItem;
+    const atEnd = isScrollEnd || isLastItem;
 
     const nextHideLeft = (!isRTL && atStart) || (isRTL && atEnd);
     const nextHideRight = (isRTL && atStart) || (!isRTL && atEnd);

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -496,7 +496,7 @@ class SlideshowView extends React.Component {
     let centeredItemOrGroupIdx;
 
     if (!this.scrollElement || !itemsOrGroups || itemsOrGroups.length === 0) {
-      return 0; // Default to first item if scroll element is not ready
+      return 0;
     }
 
     const scrollPositionAtTheMiddleOfTheGallery = this.scrollPositionAtTheMiddleOfTheGallery();

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -83,11 +83,10 @@ class SlideshowView extends React.Component {
     ) {
       return false;
     }
-    const allItemsLoaded = this.isAllItemsLoaded(props);
-    const scrollPosAtEnd = this.scrollPositionAtTheAndOfTheGallery(props);
-    const scrollElementWidth = Math.floor(this.getScrollElementWidth(props));
-    const result = allItemsLoaded && scrollPosAtEnd >= scrollElementWidth;
-    return result;
+    return (
+      this.isAllItemsLoaded(props) &&
+      this.scrollPositionAtTheAndOfTheGallery(props) >= Math.floor(this.getScrollElementWidth(props))
+    );
   }
 
   isAllItemsLoaded(props = this.props) {

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -49,8 +49,12 @@ class SlideshowView extends React.Component {
       activeIndex: props.activeIndex || 0,
       isInView: true,
       pauseAutoSlideshowClicked: false,
-      hideLeftArrow: false, // Initialize to false, will be updated by removeArrowsIfNeeded
-      hideRightArrow: false, // Initialize to false, will be updated by removeArrowsIfNeeded
+      hideLeftArrow:
+        props.options.behaviourParams_gallery_layoutDirection ===
+        GALLERY_CONSTS[optionsMap.behaviourParams.gallery.layoutDirection].LEFT_TO_RIGHT,
+      hideRightArrow:
+        props.options.behaviourParams_gallery_layoutDirection ===
+        GALLERY_CONSTS[optionsMap.behaviourParams.gallery.layoutDirection].RIGHT_TO_LEFT,
       shouldBlockAutoSlideshow: false,
       isInFocus: false,
     };

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -494,11 +494,6 @@ class SlideshowView extends React.Component {
   getCenteredItemOrGroupIdxByScroll(key) {
     const itemsOrGroups = this.props.galleryStructure[key];
     let centeredItemOrGroupIdx;
-
-    if (!this.scrollElement || !itemsOrGroups || itemsOrGroups.length === 0) {
-      return 0;
-    }
-
     const scrollPositionAtTheMiddleOfTheGallery = this.scrollPositionAtTheMiddleOfTheGallery();
 
     if (scrollPositionAtTheMiddleOfTheGallery === 0) {
@@ -512,7 +507,7 @@ class SlideshowView extends React.Component {
         }
       }
     }
-    if (centeredItemOrGroupIdx < 0 || centeredItemOrGroupIdx >= itemsOrGroups.length) {
+    if (!(centeredItemOrGroupIdx >= 0)) {
       centeredItemOrGroupIdx = 0;
     }
     return centeredItemOrGroupIdx;
@@ -1150,7 +1145,7 @@ class SlideshowView extends React.Component {
     if (this.state.activeIndex > 0) {
       this.props.actions.scrollToItem(this.state.activeIndex);
       this.onCurrentItemChanged();
-    } else if (this.scrollElement) {
+    } else {
       this.setCurrentItemByScroll();
     }
     this.startAutoSlideshowIfNeeded(this.props.options);

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -111,8 +111,8 @@ class SlideshowView extends React.Component {
     return !this.props.options.behaviourParams_gallery_horizontal_loop && this.isScrollEnd();
   }
 
-  isLastItem(props = this.props) {
-    const activeIndex = this.state.activeIndex ?? props?.activeIndex;
+  isLastItem() {
+    const activeIndex = this.state.activeIndex;
     return !this.props.options.behaviourParams_gallery_horizontal_loop && activeIndex >= this.props.totalItemsCount - 1;
   }
 
@@ -1118,7 +1118,7 @@ class SlideshowView extends React.Component {
     const isScrollStart = this.isScrollStart(props);
     const isFirstItem = this.isFirstItem();
     const isScrollEnd = this.isScrollEnd(props);
-    const isLastItem = this.isLastItem(props);
+    const isLastItem = this.isLastItem();
 
     const atStart = isScrollStart || isFirstItem;
     const atEnd = isScrollEnd || isLastItem;

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -494,6 +494,11 @@ class SlideshowView extends React.Component {
   getCenteredItemOrGroupIdxByScroll(key) {
     const itemsOrGroups = this.props.galleryStructure[key];
     let centeredItemOrGroupIdx;
+
+    if (!this.scrollElement || !itemsOrGroups || itemsOrGroups.length === 0) {
+      return 0; // Default to first item if scroll element is not ready
+    }
+
     const scrollPositionAtTheMiddleOfTheGallery = this.scrollPositionAtTheMiddleOfTheGallery();
 
     if (scrollPositionAtTheMiddleOfTheGallery === 0) {
@@ -507,8 +512,8 @@ class SlideshowView extends React.Component {
         }
       }
     }
-    if (!(centeredItemOrGroupIdx >= 0)) {
-      centeredItemOrGroupIdx = itemsOrGroups.length - 1;
+    if (!(centeredItemOrGroupIdx >= 0) || centeredItemOrGroupIdx >= itemsOrGroups.length) {
+      centeredItemOrGroupIdx = 0;
     }
     return centeredItemOrGroupIdx;
   }
@@ -533,9 +538,6 @@ class SlideshowView extends React.Component {
       return;
     }
     this.startAutoSlideshowIfNeeded(this.props.options);
-    if (isEditMode()) {
-      return this.state.activeIndex;
-    }
 
     const activeIndex = this.getCenteredItemOrGroupIdxByScroll('galleryItems');
 
@@ -1149,7 +1151,11 @@ class SlideshowView extends React.Component {
       this.props.actions.scrollToItem(this.state.activeIndex);
       this.onCurrentItemChanged();
     } else {
-      this.setCurrentItemByScroll();
+      // Only call setCurrentItemByScroll if we have a proper scroll element
+      // This prevents the issue where scroll position detection fails in EDIT mode
+      if (this.scrollElement && this.scrollElement.scrollLeft !== undefined) {
+        this.setCurrentItemByScroll();
+      }
     }
     this.startAutoSlideshowIfNeeded(this.props.options);
     this.createOrGetCustomNavigationPanelAPI();

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -111,8 +111,8 @@ class SlideshowView extends React.Component {
     return !this.props.options.behaviourParams_gallery_horizontal_loop && this.isScrollEnd();
   }
 
-  isLastItem() {
-    const activeIndex = this.state.activeIndex;
+  isLastItem(props = this.props) {
+    const activeIndex = this.state.activeIndex ?? props?.activeIndex;
     return !this.props.options.behaviourParams_gallery_horizontal_loop && activeIndex >= this.props.totalItemsCount - 1;
   }
 
@@ -1118,7 +1118,7 @@ class SlideshowView extends React.Component {
     const isScrollStart = this.isScrollStart(props);
     const isFirstItem = this.isFirstItem();
     const isScrollEnd = this.isScrollEnd(props);
-    const isLastItem = this.isLastItem();
+    const isLastItem = this.isLastItem(props);
 
     const atStart = isScrollStart || isFirstItem;
     const atEnd = isScrollEnd || isLastItem;

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -512,7 +512,7 @@ class SlideshowView extends React.Component {
         }
       }
     }
-    if (!(centeredItemOrGroupIdx >= 0) || centeredItemOrGroupIdx >= itemsOrGroups.length) {
+    if (centeredItemOrGroupIdx < 0 || centeredItemOrGroupIdx >= itemsOrGroups.length) {
       centeredItemOrGroupIdx = 0;
     }
     return centeredItemOrGroupIdx;
@@ -1150,12 +1150,8 @@ class SlideshowView extends React.Component {
     if (this.state.activeIndex > 0) {
       this.props.actions.scrollToItem(this.state.activeIndex);
       this.onCurrentItemChanged();
-    } else {
-      // Only call setCurrentItemByScroll if we have a proper scroll element
-      // This prevents the issue where scroll position detection fails in EDIT mode
-      if (this.scrollElement && this.scrollElement.scrollLeft !== undefined) {
-        this.setCurrentItemByScroll();
-      }
+    } else if (this.scrollElement) {
+      this.setCurrentItemByScroll();
     }
     this.startAutoSlideshowIfNeeded(this.props.options);
     this.createOrGetCustomNavigationPanelAPI();

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -508,7 +508,7 @@ class SlideshowView extends React.Component {
       }
     }
     if (!(centeredItemOrGroupIdx >= 0)) {
-      centeredItemOrGroupIdx = 0;
+      centeredItemOrGroupIdx = this.isFirstItem() ? 0 : itemsOrGroups.length - 1;
     }
     return centeredItemOrGroupIdx;
   }

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1159,9 +1159,6 @@ class SlideshowView extends React.Component {
     }
     this.startAutoSlideshowIfNeeded(this.props.options);
     this.createOrGetCustomNavigationPanelAPI();
-
-    // Initialize arrow state properly
-    this.removeArrowsIfNeeded();
   }
 
   componentWillUnmount() {

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -71,9 +71,7 @@ class SlideshowView extends React.Component {
     ) {
       return false;
     }
-    const scrollPos = this.scrollPosition(props);
-    const result = scrollPos <= 1;
-    return result;
+    return this.scrollPosition(props) <= 1;
   }
 
   isScrollEnd(props = this.props) {


### PR DESCRIPTION
## Summary - [Ticket](https://wix.atlassian.net/browse/PG-981)
In EDIT mode, the gallery's activeIndex was being incorrectly set to the last item instead of the first item (index 0) due to unreliable scroll position detection. This caused both arrows to be hidden because the gallery thought it was at the last item.

## Solution
Fixed the root cause by changing the fallback logic in `getCenteredItemOrGroupIdxByScroll()` to 0 OR length - 1 depends on the active index; In this way, we cover 2 bugs, for situations where `centeredItemOrGroupIdx` is undefined:
1. If the first one, we will set it to 0 so we will have right arrow.
2. If not, the item is the last one. When setting it to be the last one, we will handle edge cases where the last image is the active BUT the user didn't scroll to the end.

Scroll to last item (not on the end):
<img width="844" height="1093" alt="image" src="https://github.com/user-attachments/assets/d3383abc-a217-445e-a761-51d137eb4fe8" />

Scroll to the end:
<img width="849" height="1090" alt="image" src="https://github.com/user-attachments/assets/c2ce6d02-dcbf-4222-adf6-0938ef0abda2" />



## Result
- Navigation arrows are visible in EDIT mode
- Shows right arrow at first item, left arrow at last item, both in middle
- Behavior matches live/preview mode

<img width="1781" height="1044" alt="image" src="https://github.com/user-attachments/assets/b7ac291c-ade2-40e4-84ac-97b4e947f9f6" />
