### PR TITLE
Fix PG-972: Load More Images Stop Loading During Fast Scrolling

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
+++ b/packages/gallery/src/components/gallery/proGallery/galleryContainer.js
@@ -820,7 +820,8 @@ export class GalleryContainer extends React.Component {
 
   getMoreItemsIfNeeded(scrollPos) {
     if (this.deferredGettingMoreItems?.isPending) {
-      // Already getting more items so do nothing
+      this.latestScrollPosWhileBlocked = scrollPos;
+      // Already getting more items so just remember the scroll position
     } else {
       this.deferredGettingMoreItems = new Deferred();
 
@@ -863,10 +864,16 @@ export class GalleryContainer extends React.Component {
             GALLERY_CONSTS.events.NEED_MORE_ITEMS,
             this.state.items.length
           );
+
           setTimeout(() => {
             //wait a bit before allowing more items to be fetched - ugly hack before promises still not working
             this.deferredGettingMoreItems.resolve();
-          }, 2000);
+            if (this.latestScrollPosWhileBlocked !== undefined) {
+              const capturedPos = this.latestScrollPosWhileBlocked;
+              this.latestScrollPosWhileBlocked = undefined; // Clear it
+              this.getMoreItemsIfNeeded(capturedPos);
+            }
+          }, 500);
         } else {
           // No items are fetched -> reject
           this.deferredGettingMoreItems.reject();


### PR DESCRIPTION
Ticket: [PG-972](https://wix.atlassian.net/browse/PG-972)

### �� Problem
Users experienced a critical issue where clicking "Load More" followed by fast scrolling would cause the gallery to stop loading additional images until they manually "scrolled back up" to re-trigger the loading mechanism.

### 🔍 Root Cause Analysis
The issue was caused by a **timing mismatch** between user scroll events and the gallery's internal blocking mechanism:

1. **500ms Blocking Period**: After triggering `NEED_MORE_ITEMS`, the gallery blocks new `getMoreItemsIfNeeded` calls for 500ms
2. **Lost Scroll Events**: During this blocking period, rapid scroll events were completely ignored and lost
3. **Dead Zone**: Users would finish scrolling during the block, then no new events would arrive to trigger further loading

### ✅ Solution
Implemented a **scroll position capture mechanism** that:
- **Captures** the latest scroll position during blocking periods
- **Auto-processes** captured positions when the block ends
- **Eliminates** the need for workarounds like "scroll back up"

### 🔄 Flow Explanation
**Before (Broken):**
1. User clicks "Load More" → `getMoreItemsIfNeeded(0)` called
2. Items start loading → 500ms block begins  
3. User scrolls quickly → Events ignored and lost 🚫
4. Block ends → No new scroll events → Gallery stops loading
5. User must manually scroll to re-trigger

**After (Fixed):**
1. User clicks "Load More" → `getMoreItemsIfNeeded(0)` called
2. Items start loading → 500ms block begins
3. User scrolls quickly → Latest position captured in `latestScrollPosWhileBlocked` ✅
4. Block ends → Captured position auto-processed → `getMoreItemsIfNeeded(capturedPos)` called
5. Gallery seamlessly continues loading more items

### 📋 Changes Made
1. **Scroll Position Storage**: Added `latestScrollPosWhileBlocked` property to track scroll events during blocking
2. **Event Capture**: Modified `getMoreItemsIfNeeded` to capture scroll positions instead of ignoring them
3. **Auto-Processing**: Enhanced the timeout callback to automatically process captured scroll positions
4. **Performance**: Reduced blocking timeout from 2000ms to 500ms for better responsiveness