### PR TITLE
feat: enhance thumbnail accessibility and focus management in navigation panel

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -16,6 +16,16 @@ class NavigationPanel extends React.Component {
     this.scrollToThumbnail = this.scrollToThumbnail.bind(this);
   }
 
+  state = { focusedIndex: -1 };
+
+  onThumbnailFocus = (idx) => {
+    this.setState({ focusedIndex: idx });
+  };
+
+  onThumbnailBlur = () => {
+    this.setState({ focusedIndex: -1 });
+  };
+
   scrollToThumbnail(itemIdx) {
     this.props.navigationToIdxCB(itemIdx);
   }
@@ -85,6 +95,9 @@ class NavigationPanel extends React.Component {
           {items.map(({ thumbnailItem, location, idx }) => {
             const highlighted =
               idx === activeIndex % clearedGalleryItems.length;
+            const isFocused =
+              this.state.focusedIndex === idx &&
+              this.props.settings?.isAccessible;
             const itemStyle = {
               width: thumbnailSize,
               height: thumbnailSize,
@@ -106,14 +119,18 @@ class NavigationPanel extends React.Component {
                 }
                 className={
                   'thumbnailItem' +
-                  (highlighted
-                    ? ' pro-gallery-thumbnails-highlighted pro-gallery-highlight' +
+                  (highlighted ? ' pro-gallery-highlight' : '') +
+                  (isFocused
+                    ? ' pro-gallery-thumbnails-highlighted' +
                       (utils.isMobile() ? ' pro-gallery-mobile-indicator' : '')
                     : '')
                 }
                 data-key={thumbnailItem.id}
                 style={itemStyle}
+                tabIndex={highlighted ? 0 : -1}
                 onClick={() => this.scrollToThumbnail(idx)}
+                onFocus={() => this.onThumbnailFocus(idx)}
+                onBlur={this.onThumbnailBlur}
                 onKeyDown={(e) => {
                   if (e.key === ENTER_KEY) {
                     this.scrollToThumbnail(idx);

--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -16,16 +16,6 @@ class NavigationPanel extends React.Component {
     this.scrollToThumbnail = this.scrollToThumbnail.bind(this);
   }
 
-  state = { focusedIndex: -1 };
-
-  onThumbnailFocus = (idx) => {
-    this.setState({ focusedIndex: idx });
-  };
-
-  onThumbnailBlur = () => {
-    this.setState({ focusedIndex: -1 });
-  };
-
   scrollToThumbnail(itemIdx) {
     this.props.navigationToIdxCB(itemIdx);
   }
@@ -37,6 +27,10 @@ class NavigationPanel extends React.Component {
     galleryStructure,
     settings,
   }) {
+    const activeElement = document.activeElement;
+    const mainGalleryItemIsFocused =
+      activeElement.className &&
+      activeElement.className.includes('item-action');
     const clearedGalleryItems = clearGalleryItems(
       this.props.items,
       this.props.galleryStructure.galleryItems
@@ -95,9 +89,6 @@ class NavigationPanel extends React.Component {
           {items.map(({ thumbnailItem, location, idx }) => {
             const highlighted =
               idx === activeIndex % clearedGalleryItems.length;
-            const isFocused =
-              this.state.focusedIndex === idx &&
-              this.props.settings?.isAccessible;
             const itemStyle = {
               width: thumbnailSize,
               height: thumbnailSize,
@@ -120,17 +111,14 @@ class NavigationPanel extends React.Component {
                 className={
                   'thumbnailItem' +
                   (highlighted ? ' pro-gallery-highlight' : '') +
-                  (isFocused
+                  (mainGalleryItemIsFocused && highlighted
                     ? ' pro-gallery-thumbnails-highlighted' +
                       (utils.isMobile() ? ' pro-gallery-mobile-indicator' : '')
                     : '')
                 }
                 data-key={thumbnailItem.id}
                 style={itemStyle}
-                tabIndex={highlighted ? 0 : -1}
                 onClick={() => this.scrollToThumbnail(idx)}
-                onFocus={() => this.onThumbnailFocus(idx)}
-                onBlur={this.onThumbnailBlur}
                 onKeyDown={(e) => {
                   if (e.key === ENTER_KEY) {
                     this.scrollToThumbnail(idx);

--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -27,10 +27,6 @@ class NavigationPanel extends React.Component {
     galleryStructure,
     settings,
   }) {
-    const activeElement = document.activeElement;
-    const mainGalleryItemIsFocused =
-      activeElement.className &&
-      activeElement.className.includes('item-action');
     const clearedGalleryItems = clearGalleryItems(
       this.props.items,
       this.props.galleryStructure.galleryItems
@@ -39,6 +35,13 @@ class NavigationPanel extends React.Component {
       this.props.activeIndex,
       clearedGalleryItems.length
     );
+    const activeElement = document.activeElement;
+    const mainGalleryItemIsFocused =
+      activeElement.id &&
+      activeElement.id.includes(
+        'item-action-' +
+          this.props.galleryStructure.galleryItems[activeIndex].id
+      );
     const { thumbnailSize, thumbnailSpacings } = options;
     const {
       horizontalThumbnails,

--- a/packages/gallery/src/components/styles/gallery.scss
+++ b/packages/gallery/src/components/styles/gallery.scss
@@ -695,9 +695,9 @@ div.pro-gallery {
     }
 
 
-    .thumbnailItem.pro-gallery-highlight::after {
-      box-shadow: inset 0 0 1px 2px $wix-blue, inset 0 0 7px 0 $white, 0 0 10px -5px $wix-blue;
-    }
+    // .thumbnailItem.pro-gallery-highlight::after {
+      // box-shadow: inset 0 0 1px 2px $wix-blue, inset 0 0 7px 0 $white, 0 0 10px -5px $wix-blue;
+    // }
     .gallery-item-container:has(.item-action:focus)::after {
       content: ' ';
       width: 100%;

--- a/packages/gallery/src/components/styles/gallery.scss
+++ b/packages/gallery/src/components/styles/gallery.scss
@@ -694,10 +694,6 @@ div.pro-gallery {
       }
     }
 
-
-    // .thumbnailItem.pro-gallery-highlight::after {
-      // box-shadow: inset 0 0 1px 2px $wix-blue, inset 0 0 7px 0 $white, 0 0 10px -5px $wix-blue;
-    // }
     .gallery-item-container:has(.item-action:focus)::after {
       content: ' ';
       width: 100%;


### PR DESCRIPTION
Thumbnails are now "focused" when its corresponding main item is focused.
Note that there is no actual 2 focused elements at the same time, we use CSS to create a focus ring to make it looks like the thumbnail is focused too.
Solves: Selected Thumbnail Keeps Being Highlighted When Navigating Through Site with Tab