### PR TITLE
fix: handle document context for active element in navigation panel

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -35,8 +35,10 @@ class NavigationPanel extends React.Component {
       this.props.activeIndex,
       clearedGalleryItems.length
     );
-    const activeElement = document.activeElement;
+    const activeElement =
+      typeof document !== 'undefined' ? document.activeElement : null;
     const mainGalleryItemIsFocused =
+      activeElement &&
       activeElement.id &&
       activeElement.id.includes(
         'item-action-' +

--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -14,23 +14,24 @@ class NavigationPanel extends React.Component {
   constructor(props) {
     super(props);
     this.scrollToThumbnail = this.scrollToThumbnail.bind(this);
-    this.mainGalleryItemIsFocused = false;
+    this.state = { mainGalleryItemIsFocused: false };
   }
 
   scrollToThumbnail(itemIdx) {
     this.props.navigationToIdxCB(itemIdx);
   }
 
-  componentDidUpdate() {
+  UNSAFE_componentWillReceiveProps(props) {
     const activeElement =
       typeof document !== 'undefined' ? document.activeElement : null;
-    this.mainGalleryItemIsFocused =
+    const isMainGalleryItemIsFocused =
       activeElement &&
       activeElement.id &&
       activeElement.id.includes(
         'item-action-' +
-          this.props.galleryStructure.galleryItems[this.props.activeIndex].id
+          props.galleryStructure.galleryItems[props.activeIndex].id
       );
+    this.setState({ mainGalleryItemIsFocused: isMainGalleryItemIsFocused });
   }
 
   createThumbnails({
@@ -120,7 +121,7 @@ class NavigationPanel extends React.Component {
                 className={
                   'thumbnailItem' +
                   (highlighted ? ' pro-gallery-highlight' : '') +
-                  (this.mainGalleryItemIsFocused && highlighted
+                  (this.state.mainGalleryItemIsFocused && highlighted
                     ? ' pro-gallery-thumbnails-highlighted' +
                       (utils.isMobile() ? ' pro-gallery-mobile-indicator' : '')
                     : '')

--- a/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
+++ b/packages/gallery/src/components/gallery/proGallery/navigationPanel.js
@@ -14,10 +14,23 @@ class NavigationPanel extends React.Component {
   constructor(props) {
     super(props);
     this.scrollToThumbnail = this.scrollToThumbnail.bind(this);
+    this.mainGalleryItemIsFocused = false;
   }
 
   scrollToThumbnail(itemIdx) {
     this.props.navigationToIdxCB(itemIdx);
+  }
+
+  componentDidUpdate() {
+    const activeElement =
+      typeof document !== 'undefined' ? document.activeElement : null;
+    this.mainGalleryItemIsFocused =
+      activeElement &&
+      activeElement.id &&
+      activeElement.id.includes(
+        'item-action-' +
+          this.props.galleryStructure.galleryItems[this.props.activeIndex].id
+      );
   }
 
   createThumbnails({
@@ -35,15 +48,6 @@ class NavigationPanel extends React.Component {
       this.props.activeIndex,
       clearedGalleryItems.length
     );
-    const activeElement =
-      typeof document !== 'undefined' ? document.activeElement : null;
-    const mainGalleryItemIsFocused =
-      activeElement &&
-      activeElement.id &&
-      activeElement.id.includes(
-        'item-action-' +
-          this.props.galleryStructure.galleryItems[activeIndex].id
-      );
     const { thumbnailSize, thumbnailSpacings } = options;
     const {
       horizontalThumbnails,
@@ -116,7 +120,7 @@ class NavigationPanel extends React.Component {
                 className={
                   'thumbnailItem' +
                   (highlighted ? ' pro-gallery-highlight' : '') +
-                  (mainGalleryItemIsFocused && highlighted
+                  (this.mainGalleryItemIsFocused && highlighted
                     ? ' pro-gallery-thumbnails-highlighted' +
                       (utils.isMobile() ? ' pro-gallery-mobile-indicator' : '')
                     : '')


### PR DESCRIPTION
SSR should not render focus rings, and don't have access to the html document. This PR solves this issue.