### PR TITLE
Fix: use last valid index instead of resetting to 0

### DIFF
--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -1169,11 +1169,12 @@ class SlideshowView extends React.Component {
       });
     }
     if (this.state.activeIndex > props.items.length - 1) {
+      const lastValidIndex = Math.max(0, props.items.length - 1);
       utils.setStateAndLog(
         this,
         'Next Item',
         {
-          activeIndex: 0,
+          activeIndex: lastValidIndex,
         },
         () => {
           this.onCurrentItemChanged();

--- a/packages/gallery/src/components/gallery/proGallery/slideshowView.js
+++ b/packages/gallery/src/components/gallery/proGallery/slideshowView.js
@@ -346,8 +346,17 @@ class SlideshowView extends React.Component {
         scrollDuration,
         scrollingUpTheGallery
       );
-      const nextItem =
-        this.getCenteredItemOrGroupIdxByScroll('galleryItems') + direction;
+      let nextItem = this.getCenteredItemOrGroupIdxByScroll('galleryItems');
+      if (this.props.options.slideshowLoop) {
+        nextItem += direction;
+      } else {
+        if (direction > 0 && nextItem < this.props.totalItemsCount - 1) {
+          nextItem += direction;
+        } else if (direction < 0 && nextItem > 0) {
+          nextItem += direction;
+        }
+      }
+
       this.onScrollToItemOrGroup(nextItem, isContinuousScrolling);
     } catch (e) {
       this.onThrowScrollError('Cannot proceed to the next Group', e);
@@ -1169,12 +1178,11 @@ class SlideshowView extends React.Component {
       });
     }
     if (this.state.activeIndex > props.items.length - 1) {
-      const lastValidIndex = Math.max(0, props.items.length - 1);
       utils.setStateAndLog(
         this,
         'Next Item',
         {
-          activeIndex: lastValidIndex,
+          activeIndex: 0,
         },
         () => {
           this.onCurrentItemChanged();


### PR DESCRIPTION
### Summary of Changes
The fix addresses the root cause of the `activeIndex` becoming 12 when there are only 12 items (indices 0-11). The issue was in the `nextGroup` method where it was blindly adding the direction (+1) to the current index without checking if we were already at the last item.

### Solution
Instead of always adding the direction, the code now checks boundary conditions first:
* For looping galleries: Always increment (maintains infinite loop behavior).
* For non-looping galleries: Only increment if we're not already at the boundary (prevents going out of bounds).

This prevents the `activeIndex` from exceeding the valid range and eliminates the need for the patch that was resetting it to 0 in `UNSAFE_componentWillReceiveProps`.

### Old changes that needed to support
TPA change (older): [PR](https://github.com/wix-private/photography-pro-gallery-tpa/commit/00dc80882d176a1106e9b5c8d8116b984bd320d4)).
Pro-gallery change (actual behavior): [PR](https://github.com/wix-incubator/pro-gallery/commit/900e047b637d8dec2c1908f41571af6a47572a47).




