### PR TITLE
Ignore non-fatal HLS bufferSeekOverHole warnings in ReactPlayer

### DIFF
--- a/packages/gallery/src/components/item/videos/videoItem.js
+++ b/packages/gallery/src/components/item/videos/videoItem.js
@@ -235,10 +235,17 @@ class VideoItem extends React.Component {
         onPause={() => {
           this.setState({ isPlaying: false });
         }}
-        onError={(e) => {
+        onError={(error, data) => {
+          if (
+            error === 'hlsError' &&
+            data?.details === 'bufferSeekOverHole' &&
+            data?.fatal === false
+          ) {
+            return;
+          }
           this.props.actions.eventsListener(GALLERY_CONSTS.events.VIDEO_ERROR, {
             ...this.props,
-            videoError: e,
+            videoError: error,
           });
         }}
         playbackRate={Number(this.props.options.videoSpeed) || 1}


### PR DESCRIPTION
While playing HLS videos in the Pro Gallery, ReactPlayer was reporting an `"hlsError"` with `bufferSeekOverHole` in `onError`. This happens when there is a minor gap in the video stream’s buffered segments. **It is non-fatal and does not affect playback**, but it was being sent as a video error event which triggered our pause event.

Change:
- Updated the `onError` handler to ignore non-fatal bufferSeekOverHole HLS warnings.
- All other errors, including fatal HLS or other video errors, are still reported via `VIDEO_ERROR`.

Solves:
Pro Gallery Videos Automatically Stop After First Click